### PR TITLE
feat: launch unit 8 practice test experience

### DIFF
--- a/bus-math-nextjs/src/app/student/unit08/practice-test/page.tsx
+++ b/bus-math-nextjs/src/app/student/unit08/practice-test/page.tsx
@@ -1,0 +1,627 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { PhaseHeader, type LessonPhase } from "@/components/student/PhaseHeader"
+import { PhaseFooter } from "@/components/student/PhaseFooter"
+import ComprehensionCheck from "@/components/exercises/ComprehensionCheck"
+import ReflectionJournal from "@/components/exercises/ReflectionJournal"
+import {
+  drawRandomUnit08Phase5Questions,
+  getUnit08Phase5Questions,
+  toComprehensionCheckItems,
+  type Unit08LessonId,
+  type Unit08Phase5Question
+} from "@/data/question-banks/unit08-phase5"
+import { practiceTestLessonData, practiceTestPhases, unit08Data } from "./practice-test-data"
+import { cn } from "@/lib/utils"
+import { CheckCircle2, ListChecks, NotebookPen, RefreshCw, Sparkles, Target, Timer, Wand2 } from "lucide-react"
+
+const PRACTICE_TEST_STORAGE_KEY = "unit08_practice_test_state_v1"
+
+const lessonOptions: Array<{
+  id: Unit08LessonId
+  title: string
+  focus: string
+  color: string
+}> = [
+  {
+    id: "lesson01",
+    title: "Lesson 01 – VC Red Flags & Entry Event",
+    focus: "Venture capital evaluation criteria and common startup model failures",
+    color: "border-rose-300 bg-rose-50"
+  },
+  {
+    id: "lesson02",
+    title: "Lesson 02 – Review & Link Integration",
+    focus: "Cross-sheet linking and integrated financial statement fundamentals",
+    color: "border-sky-300 bg-sky-50"
+  },
+  {
+    id: "lesson03",
+    title: "Lesson 03 – Balance Sheet & Cash Flow Integration",
+    focus: "Working capital dynamics and cash flow reconciliation",
+    color: "border-emerald-300 bg-emerald-50"
+  },
+  {
+    id: "lesson04",
+    title: "Lesson 04 – Scenario Manager & Advanced Modeling",
+    focus: "Scenario analysis and professional financial model architecture",
+    color: "border-amber-300 bg-amber-50"
+  },
+  {
+    id: "lesson05",
+    title: "Lesson 05 – Sensitivity & Scenario Automation",
+    focus: "Data tables, sensitivity analysis, and automated scenario testing",
+    color: "border-purple-300 bg-purple-50"
+  },
+  {
+    id: "lesson06",
+    title: "Lesson 06 – Integration & Dashboard",
+    focus: "KPI dashboards, dynamic charts, and investor-ready presentation",
+    color: "border-cyan-300 bg-cyan-50"
+  },
+  {
+    id: "lesson07",
+    title: "Lesson 07 – Production Studio & QA",
+    focus: "Final quality assurance, audit trails, and investor readiness",
+    color: "border-indigo-300 bg-indigo-50"
+  }
+]
+
+type StoredResult = {
+  score: number
+  total: number
+  percentage: number
+  completedAt: string
+  lessonBreakdown: Record<Unit08LessonId, number>
+}
+
+type StoredState = {
+  selectedLessonIds: Unit08LessonId[]
+  questionCount: number
+  lastResult?: StoredResult
+}
+
+export default function PracticeTestPage() {
+  const defaultLessonSelection = lessonOptions.map(option => option.id)
+  const [selectedLessonIds, setSelectedLessonIds] = useState<Unit08LessonId[]>(defaultLessonSelection)
+  const [questionCount, setQuestionCount] = useState<number>(12)
+  const [activeQuestions, setActiveQuestions] = useState<Unit08Phase5Question[]>([])
+  const [lastResult, setLastResult] = useState<StoredResult | undefined>(undefined)
+  const [isHydrated, setIsHydrated] = useState(false)
+  const phasesForNavigation: LessonPhase[] = practiceTestPhases.map(phase => ({
+    id: phase.id,
+    phaseName: phase.phaseName,
+    sequence: phase.sequence,
+    description: phase.description
+  }))
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return
+    }
+
+    try {
+      const stored = window.localStorage.getItem(PRACTICE_TEST_STORAGE_KEY)
+      if (stored) {
+        const parsed: StoredState = JSON.parse(stored)
+        if (Array.isArray(parsed.selectedLessonIds) && parsed.selectedLessonIds.length > 0) {
+          setSelectedLessonIds(parsed.selectedLessonIds)
+        }
+        if (typeof parsed.questionCount === "number" && parsed.questionCount > 0) {
+          setQuestionCount(parsed.questionCount)
+        }
+        if (parsed.lastResult) {
+          setLastResult(parsed.lastResult)
+        }
+      }
+    } catch (error) {
+      console.error("Failed to load practice test state", error)
+    } finally {
+      setIsHydrated(true)
+    }
+  }, [])
+
+  const availableQuestions = useMemo(() => {
+    if (selectedLessonIds.length === 0) {
+      return []
+    }
+    return getUnit08Phase5Questions({ lessonIds: selectedLessonIds })
+  }, [selectedLessonIds])
+
+  const maxSelectableQuestions = availableQuestions.length
+
+  useEffect(() => {
+    if (!isHydrated) {
+      return
+    }
+
+    if (maxSelectableQuestions === 0) {
+      setQuestionCount(0)
+      return
+    }
+
+    setQuestionCount(prev => {
+      if (prev === 0) {
+        return Math.min(12, maxSelectableQuestions)
+      }
+      return Math.min(prev, maxSelectableQuestions)
+    })
+  }, [isHydrated, maxSelectableQuestions])
+
+  useEffect(() => {
+    if (!isHydrated) {
+      return
+    }
+
+    const stateToStore: StoredState = {
+      selectedLessonIds,
+      questionCount,
+      lastResult
+    }
+
+    try {
+      window.localStorage.setItem(PRACTICE_TEST_STORAGE_KEY, JSON.stringify(stateToStore))
+    } catch (error) {
+      console.error("Failed to persist practice test state", error)
+    }
+  }, [isHydrated, selectedLessonIds, questionCount, lastResult])
+
+  const handleToggleLesson = (lessonId: Unit08LessonId) => {
+    setSelectedLessonIds(previous => {
+      if (previous.includes(lessonId)) {
+        return previous.filter(id => id !== lessonId)
+      }
+      return [...previous, lessonId]
+    })
+  }
+
+  const handleSelectAllLessons = () => {
+    const allSelected = selectedLessonIds.length === lessonOptions.length
+    setSelectedLessonIds(allSelected ? [] : lessonOptions.map(option => option.id))
+  }
+
+  const handleQuestionCountChange = (value: number) => {
+    if (Number.isNaN(value) || value < 0) {
+      return
+    }
+    if (maxSelectableQuestions === 0) {
+      setQuestionCount(0)
+      return
+    }
+    const clamped = Math.min(Math.max(value, 1), maxSelectableQuestions)
+    setQuestionCount(clamped)
+  }
+
+  const startPracticeTest = () => {
+    if (selectedLessonIds.length === 0 || maxSelectableQuestions === 0) {
+      return
+    }
+
+    const questions = drawRandomUnit08Phase5Questions(questionCount, {
+      lessonIds: selectedLessonIds
+    })
+    setActiveQuestions(questions)
+    if (typeof window !== "undefined") {
+      const focusTarget = document.getElementById("phase-4")
+      focusTarget?.scrollIntoView({ behavior: "smooth", block: "start" })
+    }
+  }
+
+  const handleResetAll = () => {
+    setSelectedLessonIds(defaultLessonSelection)
+    setQuestionCount(12)
+    setActiveQuestions([])
+    setLastResult(undefined)
+    try {
+      window.localStorage.removeItem(PRACTICE_TEST_STORAGE_KEY)
+    } catch (error) {
+      console.error("Failed to clear practice test state", error)
+    }
+  }
+
+  const comprehensionItems = useMemo(() => {
+    return toComprehensionCheckItems(activeQuestions)
+  }, [activeQuestions])
+
+  const lessonBreakdown = useMemo(() => {
+    return activeQuestions.reduce<Record<Unit08LessonId, number>>((acc, question) => {
+      acc[question.lessonId] = (acc[question.lessonId] ?? 0) + 1
+      return acc
+    }, {} as Record<Unit08LessonId, number>)
+  }, [activeQuestions])
+
+  const currentPhase = phasesForNavigation.find(phase => phase.sequence === 5)!
+
+  const navigationOverrides = {
+    lessonHref: "/student/unit08/practice-test",
+    lessonLabel: "Practice Test",
+    phaseLabel: "Practice Test"
+  }
+
+  const footerNavigationOverrides = {
+    lessonHref: "/student/unit08/practice-test",
+    lessonOverviewLabel: "Practice Test Overview",
+    backToLessonLabel: "Back to Practice Test Overview",
+    completeLessonLabel: "Finish Practice Test",
+    phaseHrefBuilder: (phase: LessonPhase) => `/student/unit08/practice-test#phase-${phase.sequence}`
+  }
+
+  const lastCompletionTime = lastResult
+    ? new Date(lastResult.completedAt).toLocaleString(undefined, {
+        dateStyle: "medium",
+        timeStyle: "short"
+      })
+    : null
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-violet-50">
+      <div className="container mx-auto px-4 py-8 space-y-8">
+        <PhaseHeader
+          lesson={practiceTestLessonData}
+          unit={unit08Data}
+          phase={currentPhase}
+          phases={phasesForNavigation}
+          navigationOverrides={navigationOverrides}
+        />
+
+        <main className="space-y-12">
+          <section id="phase-1" className="space-y-6">
+            <div className="text-center space-y-4">
+              <Badge className="bg-rose-100 text-rose-800 text-lg px-4 py-2">
+                ✨ Phase 1: Hook – Investor Spotlight
+              </Badge>
+              <Card className="max-w-4xl mx-auto border-rose-200 bg-white">
+                <CardHeader>
+                  <CardTitle className="flex items-center justify-center gap-2 text-rose-900">
+                    <Sparkles className="h-5 w-5" />
+                    Sarah's VC pitch rehearsal starts now
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-4 text-left">
+                  <p className="text-lg leading-relaxed text-slate-800">
+                    Sarah Chen is three days away from pitching TechStart Solutions to a venture capital panel. She
+                    already built the Year-1 Startup Model with integrated statements and scenario analysis, but VCs
+                    expect her to answer rapid-fire questions about every assumption, formula, and cash balance. This
+                    practice test is your chance to rehearse alongside Sarah so both of you are ready for the real Q&amp;A.
+                  </p>
+                  <div className="bg-rose-50 border border-rose-200 rounded-lg p-4 text-rose-900">
+                    <h3 className="font-semibold mb-2">Why this matters</h3>
+                    <p className="text-sm leading-relaxed">
+                      Venture capitalists judge startups on clarity, speed, and confidence. When you can defend the
+                      model's assumptions without hesitation, you prove the business is disciplined and investor-ready.
+                      Your mastery keeps Sarah's credibility high and the conversation focused on the value she delivers,
+                      not on errors that could have been caught with stronger preparation.
+                    </p>
+                  </div>
+                </CardContent>
+              </Card>
+            </div>
+          </section>
+
+          <section id="phase-2" className="space-y-6">
+            <div className="text-center space-y-4">
+              <Badge className="bg-sky-100 text-sky-800 text-lg px-4 py-2">
+                ⚙️ Phase 2: Introduction – Build Your Test Plan
+              </Badge>
+              <div className="max-w-4xl mx-auto space-y-6">
+                <Card className="border-sky-200 bg-white">
+                  <CardHeader>
+                    <CardTitle className="flex items-center justify-center gap-2 text-sky-900">
+                      <Wand2 className="h-5 w-5" />
+                      Tune the challenge to match your goals
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-4 text-left text-slate-800">
+                    <p className="text-lg leading-relaxed">
+                      Decide which lessons you want to focus on today. Each set pulls from the shared question bank that
+                      powers every lesson's assessment. Use the toggles below to highlight the skills you want to
+                      reinforce before the VC pitch.
+                    </p>
+                    <div className="flex flex-wrap gap-3">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        onClick={handleSelectAllLessons}
+                        className="border-dashed"
+                      >
+                        {selectedLessonIds.length === lessonOptions.length ? "Clear lesson filters" : "Select every lesson"}
+                      </Button>
+                      <Badge variant="secondary" className="text-sm">
+                        {selectedLessonIds.length} of {lessonOptions.length} lessons active
+                      </Badge>
+                      <Badge variant="outline" className="text-sm">
+                        {maxSelectableQuestions} questions available with current filters
+                      </Badge>
+                    </div>
+                    <div className="grid gap-3">
+                      {lessonOptions.map(option => {
+                        const isSelected = selectedLessonIds.includes(option.id)
+                        return (
+                          <label
+                            key={option.id}
+                            className={cn(
+                              "flex items-start gap-3 rounded-lg border p-4 transition",
+                              isSelected
+                                ? `${option.color} shadow-sm`
+                                : "border-slate-200 bg-white hover:border-slate-300"
+                            )}
+                          >
+                            <input
+                              type="checkbox"
+                              className="mt-1 h-4 w-4"
+                              checked={isSelected}
+                              onChange={() => handleToggleLesson(option.id)}
+                              aria-label={`Toggle ${option.title}`}
+                            />
+                            <div className="space-y-1">
+                              <p className="font-semibold text-slate-900">{option.title}</p>
+                              <p className="text-sm text-slate-700">{option.focus}</p>
+                            </div>
+                          </label>
+                        )
+                      })}
+                    </div>
+                  </CardContent>
+                </Card>
+              </div>
+            </div>
+          </section>
+
+          <section id="phase-3" className="space-y-6">
+            <div className="text-center space-y-4">
+              <Badge className="bg-emerald-100 text-emerald-800 text-lg px-4 py-2">
+                🧭 Phase 3: Guided Practice – Strategy Huddle
+              </Badge>
+              <div className="max-w-4xl mx-auto grid gap-6">
+                <Card className="border-emerald-200 bg-white">
+                  <CardHeader>
+                    <CardTitle className="flex items-center justify-center gap-2 text-emerald-900">
+                      <Target className="h-5 w-5" />
+                      Smart habits before you press start
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="grid gap-4 text-left text-slate-800">
+                    <ul className="list-disc list-inside space-y-2 text-sm">
+                      <li>
+                        Commit to a steady pace. VCs expect confident answers in under a minute, so practice
+                        finishing each item within 60 seconds.
+                      </li>
+                      <li>
+                        Read the prompt, anchor it to Sarah's startup model, then scan for the answer that protects
+                        accuracy and investor confidence.
+                      </li>
+                      <li>
+                        Use the explanations after you submit. They show the exact reasoning Sarah will share in the
+                        VC meeting.
+                      </li>
+                      <li>
+                        Flag any question that slows you down. Revisit the matching lesson before your next attempt.
+                      </li>
+                    </ul>
+                    <div className="bg-emerald-50 border border-emerald-200 rounded-lg p-4 text-emerald-900">
+                      <h3 className="font-semibold mb-2">Warm-up prompt</h3>
+                      <p className="text-sm leading-relaxed">
+                        Imagine a VC asks, "How do you ensure this model stays accurate when assumptions change?" Spend
+                        30 seconds describing the integration check you would spotlight first. That mindset will guide
+                        you through the toughest questions ahead.
+                      </p>
+                    </div>
+                  </CardContent>
+                </Card>
+              </div>
+            </div>
+          </section>
+
+          <section id="phase-4" className="space-y-6">
+            <div className="text-center space-y-4">
+              <Badge className="bg-amber-100 text-amber-800 text-lg px-4 py-2">
+                ⏱️ Phase 4: Independent Practice – Take the Test
+              </Badge>
+              <div className="max-w-4xl mx-auto space-y-6">
+                <Card className="border-amber-200 bg-white">
+                  <CardHeader>
+                    <CardTitle className="flex items-center justify-center gap-2 text-amber-900">
+                      <Timer className="h-5 w-5" />
+                      Configure your question set
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-4 text-left text-slate-800">
+                    <div className="flex flex-col gap-2">
+                      <label htmlFor="question-count" className="text-sm font-medium text-slate-700">
+                        Number of questions (max {maxSelectableQuestions || 0})
+                      </label>
+                      <Input
+                        id="question-count"
+                        type="number"
+                        min={maxSelectableQuestions === 0 ? 0 : 1}
+                        max={Math.max(maxSelectableQuestions, 1)}
+                        value={questionCount}
+                        onChange={event => handleQuestionCountChange(Number(event.target.value))}
+                        disabled={maxSelectableQuestions === 0}
+                      />
+                    </div>
+                    <div className="flex flex-wrap gap-3">
+                      <Button
+                        type="button"
+                        onClick={startPracticeTest}
+                        disabled={selectedLessonIds.length === 0 || maxSelectableQuestions === 0}
+                        className="flex items-center gap-2"
+                      >
+                        <ListChecks className="h-4 w-4" />
+                        Start practice test
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        onClick={handleResetAll}
+                        className="flex items-center gap-2"
+                      >
+                        <RefreshCw className="h-4 w-4" />
+                        Reset filters &amp; progress
+                      </Button>
+                    </div>
+                    <p className="text-sm text-slate-600">
+                      Tip: Want a tougher round? Narrow the lesson focus or increase your question count until you hit
+                      the maximum available.
+                    </p>
+                  </CardContent>
+                </Card>
+
+                {activeQuestions.length > 0 ? (
+                  <ComprehensionCheck
+                    questions={comprehensionItems}
+                    title="Unit 8 Practice Test"
+                    description="Answer the questions, then review the explanations to strengthen your investor-ready pitch."
+                    showExplanations={true}
+                    allowRetry={true}
+                    onComplete={(score, total) => {
+                      const computedBreakdown = { ...lessonBreakdown }
+                      setLastResult({
+                        score,
+                        total,
+                        percentage: Math.round((score / total) * 100),
+                        completedAt: new Date().toISOString(),
+                        lessonBreakdown: computedBreakdown
+                      })
+                    }}
+                  />
+                ) : (
+                  <Card className="border-dashed border-amber-300 bg-amber-50">
+                    <CardHeader>
+                      <CardTitle className="text-center text-amber-900">
+                        Configure your set and press "Start practice test" to begin.
+                      </CardTitle>
+                    </CardHeader>
+                  </Card>
+                )}
+              </div>
+            </div>
+          </section>
+
+          <section id="phase-5" className="space-y-6">
+            <div className="text-center space-y-4">
+              <Badge className="bg-orange-100 text-orange-800 text-lg px-4 py-2">
+                🧮 Phase 5: Assessment – Score &amp; Insights
+              </Badge>
+              <div className="max-w-4xl mx-auto grid gap-6">
+                <Card className="border-orange-200 bg-white">
+                  <CardHeader>
+                    <CardTitle className="flex items-center justify-center gap-2 text-orange-900">
+                      <CheckCircle2 className="h-5 w-5" />
+                      Your current score snapshot
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="grid gap-4 text-left text-slate-800">
+                    {lastResult ? (
+                      <div className="grid gap-4">
+                        <div className="flex flex-wrap items-center justify-between gap-3">
+                          <Badge variant={lastResult.percentage >= 80 ? "default" : "destructive"} className="text-lg px-3 py-1">
+                            {lastResult.score} / {lastResult.total} correct ({lastResult.percentage}% mastery)
+                          </Badge>
+                          {lastCompletionTime && (
+                            <span className="text-sm text-slate-600">Last attempt: {lastCompletionTime}</span>
+                          )}
+                        </div>
+                        <div className="bg-orange-50 border border-orange-200 rounded-lg p-4 text-orange-900 space-y-2">
+                          <p className="font-semibold">Reading the results</p>
+                          <p className="text-sm leading-relaxed">
+                            A score of 80% or higher means you can defend Sarah's startup model with confidence. If you
+                            scored lower, focus on the lessons with the largest slice in the breakdown below before the
+                            next VC rehearsal.
+                          </p>
+                        </div>
+                        <div className="grid gap-3">
+                          {lessonOptions.map(option => {
+                            const count = lastResult.lessonBreakdown[option.id] ?? 0
+                            if (count === 0) {
+                              return null
+                            }
+                            return (
+                              <div
+                                key={`breakdown-${option.id}`}
+                                className="flex items-center justify-between rounded-lg border border-slate-200 bg-slate-50 px-4 py-2 text-sm"
+                              >
+                                <span className="font-medium text-slate-800">{option.title}</span>
+                                <span className="text-slate-600">{count} question{count !== 1 ? "s" : ""}</span>
+                              </div>
+                            )
+                          })}
+                        </div>
+                      </div>
+                    ) : (
+                      <p className="text-sm text-slate-600">
+                        Complete a practice round to see your live score, lesson breakdown, and targeted improvement
+                        advice.
+                      </p>
+                    )}
+                  </CardContent>
+                </Card>
+              </div>
+            </div>
+          </section>
+
+          <section id="phase-6" className="space-y-6">
+            <div className="text-center space-y-4">
+              <Badge className="bg-indigo-100 text-indigo-800 text-lg px-4 py-2">
+                🪞 Phase 6: Closing – Reflect &amp; Plan Ahead
+              </Badge>
+              <div className="max-w-4xl mx-auto space-y-6">
+                <Card className="border-indigo-200 bg-white">
+                  <CardHeader>
+                    <CardTitle className="flex items-center justify-center gap-2 text-indigo-900">
+                      <NotebookPen className="h-5 w-5" />
+                      Lock in your next move
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-4 text-left text-slate-800">
+                    <p className="text-lg leading-relaxed">
+                      Sarah ends every rehearsal by writing one improvement move and one strength she wants to showcase.
+                      Do the same here. The next VC meeting depends on consistent reflection and rapid iteration.
+                    </p>
+                    <ReflectionJournal
+                      unitTitle="Unit 8 Practice Test Reflection"
+                      prompts={[
+                        {
+                          id: "unit08-practice-test-reflection-strength",
+                          category: "courage",
+                          prompt: "What financial modeling move did you handle with confidence during this practice test, and how will you showcase it in the VC pitch?",
+                          placeholder: "Describe the question or concept you handled well and the evidence you will share with investors..."
+                        },
+                        {
+                          id: "unit08-practice-test-reflection-focus",
+                          category: "persistence",
+                          prompt: "Which modeling skill still needs polish before the next sprint check-in, and what action will you take to strengthen it?",
+                          placeholder: "Explain the tricky area you want to improve and the specific practice plan you will use..."
+                        }
+                      ]}
+                    />
+                    <div className="bg-indigo-50 border border-indigo-200 rounded-lg p-4 text-indigo-900 space-y-2">
+                      <h3 className="font-semibold">Ready for the next rep?</h3>
+                      <p className="text-sm leading-relaxed">
+                        Repeat this practice test with a new question mix tomorrow. Consistent rehearsal keeps Sarah's
+                        VC pitch tight and your financial modeling instincts sharp when the questions get tough.
+                      </p>
+                    </div>
+                  </CardContent>
+                </Card>
+              </div>
+            </div>
+          </section>
+        </main>
+
+        <PhaseFooter
+          lesson={practiceTestLessonData}
+          unit={unit08Data}
+          phase={currentPhase}
+          phases={phasesForNavigation}
+          navigationOverrides={footerNavigationOverrides}
+        />
+      </div>
+    </div>
+  )
+}

--- a/bus-math-nextjs/src/app/student/unit08/practice-test/practice-test-data.ts
+++ b/bus-math-nextjs/src/app/student/unit08/practice-test/practice-test-data.ts
@@ -1,0 +1,51 @@
+import { unit08Data } from "../lesson01/lesson-data"
+
+export const practiceTestLessonData = {
+  id: "unit08-practice-test",
+  title: "Unit 8 Practice Test: Investor Readiness",
+  sequence: 11,
+  unitId: unit08Data.id
+}
+
+export const practiceTestPhases = [
+  {
+    id: "unit08-practice-test-phase-1",
+    phaseName: "Hook" as const,
+    sequence: 1,
+    description: "Set the scene for Sarah's investor pitch and preview how this practice test prepares your startup model for VC scrutiny."
+  },
+  {
+    id: "unit08-practice-test-phase-2",
+    phaseName: "Introduction" as const,
+    sequence: 2,
+    description: "Review the practice-test format, adjust the filters, and lock in a question mix that matches the financial modeling skills you need most."
+  },
+  {
+    id: "unit08-practice-test-phase-3",
+    phaseName: "Guided Practice" as const,
+    sequence: 3,
+    description: "Warm up with strategy tips and checkpoints that mirror the support Sarah leans on before the real VC pitch."
+  },
+  {
+    id: "unit08-practice-test-phase-4",
+    phaseName: "Independent Practice" as const,
+    sequence: 4,
+    description: "Work through your personalized practice set. Track timing, flag tough items, and act like the lead financial analyst in Sarah's startup."
+  },
+  {
+    id: "unit08-practice-test-phase-5",
+    phaseName: "Assessment" as const,
+    sequence: 5,
+    description: "Score your performance instantly, read explanations, and pull insights that keep TechStart investor-ready."
+  },
+  {
+    id: "unit08-practice-test-phase-6",
+    phaseName: "Closing" as const,
+    sequence: 6,
+    description: "Capture reflections, celebrate progress, and set a next-step focus before the next sprint checkpoint."
+  }
+] as const
+
+export type PracticeTestPhase = (typeof practiceTestPhases)[number]
+
+export { unit08Data }

--- a/bus-math-nextjs/src/components/student/StudentUnitOverview.tsx
+++ b/bus-math-nextjs/src/components/student/StudentUnitOverview.tsx
@@ -105,6 +105,13 @@ export function StudentUnitOverview({ unit, lessons }: StudentUnitOverviewProps)
         "Ready to prove your depreciation and inventory expertise? Launch the Unit 7 practice test to rehearse method selection, FIFO vs. LIFO trade-offs, cash-flow impacts, and board-ready strategic reasoning with randomized questions from every asset and inventory lesson.",
       tip:
         "Tip: Complete Lesson 07 first so you can apply peer audit checks, model QA standards, and presentation polish while reviewing your answers."
+    },
+    8: {
+      title: "Practice Test & Investor Readiness",
+      description:
+        "Ready to prove your startup modeling mastery? Launch the Unit 8 practice test to rehearse VC evaluation criteria, integrated financial statements, scenario analysis, and investor-ready presentation standards with randomized questions from every Year-1 Startup Model lesson.",
+      tip:
+        "Tip: Complete Lesson 07 first so you can apply final QA checks, audit-readiness validation, and professional pitch polish while reviewing your answers."
     }
   }
 


### PR DESCRIPTION
## Summary
- Add dedicated /student/unit08/practice-test route with six-phase practice workflow and persistence
- Integrate with unit08-phase5 question bank for randomized question draws
- Surface practice test entry point on Unit 8 overview page with investor-readiness messaging

## Testing
- Tests passed (user-verified)
- Lesson filtering (lessons 1-7) works correctly
- Question count selection respects available pool
- localStorage persistence confirmed for filters and results
- Score breakdown and retry functionality validated
- Practice test link displays on Unit 8 overview

Closes #39