### PR TITLE
docs: update TDD workflow with build verification and chrome-devtools MCP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,20 +14,21 @@ Follow this process for every development slice to keep the repository, sprint a
 5. Branch from `main` using `<type>/<issue>-<slug>` (example: `feat/7-mcq-quiz-auto-score`). All commits for the slice stay on this branch.
 6. Practice TDD: add or update tests first, then implement. Run `npm run lint` and `npm run test` before every commit. When APIs or Prisma schema change, also run `npm run test:integration`; for broader flows, run `npm run test:e2e`.
 7. Use Conventional Commit messages (e.g., `feat: add automated scoring rubric`). Keep commits atomic and scoped to the issue.
-8. Push the branch (`git push -u origin <branch>`) and open a PR (`gh pr create --fill --label ... --milestone ...`). Link the issue, record test commands in the body, and run `gh pr checks`.
-9. Complete a self-review, address feedback on the same branch, then merge with squash (`gh pr merge --squash --delete-branch`). Ensure CI is green before merge.
-10. After merge, switch back to `main`, run `git pull --ff-only`, prune stale branches, close the linked issue (if not auto-closed), and update sprint artifacts (sprint doc, TODO.md) to reflect completion.
-11. Repeat the loop for the next prioritized issue; do not batch unrelated work on a single branch.
+8. Before final verification, terminate all running dev servers (e.g., `pkill -f "npm run dev"` or `pkill -f next`), then execute `npm run build`. Resolve any build errors before claiming the slice is complete.
+9. Push the branch (`git push -u origin <branch>`) and open a PR (`gh pr create --fill --label ... --milestone ...`). Link the issue, record test commands in the body, and run `gh pr checks`.
+10. Complete a self-review, address feedback on the same branch, then merge with squash (`gh pr merge --squash --delete-branch`). Ensure CI is green before merge.
+11. After merge, switch back to `main`, run `git pull --ff-only`, prune stale branches, close the linked issue (if not auto-closed), and update sprint artifacts (sprint doc, TODO.md) to reflect completion.
+12. Repeat the loop for the next prioritized issue; do not batch unrelated work on a single branch.
 
 ## Agent Operating Rules (Read First)
 - Work only in `bus-math-nextjs/` unless explicitly told otherwise.
-- Do NOT run `npm` commands (including `npm run build`, `npm run dev`, `npm start`, installs) or mutate `.next` without explicit user approval.
+- Avoid `npm` commands (including `npm run build`, `npm run dev`, `npm start`, installs) unless you are performing the mandatory final `npm run build` verification or have explicit user approval. Do not mutate `.next` manually.
 - Prefer fast, read‑only introspection: use `rg` (ripgrep) to search, and read files in chunks ≤250 lines.
 - Verify component exports before import: check for `export default` vs named exports in actual files.
 - Follow six‑phase page structure and the established styling wrapper from lesson03 (gradient background, `PhaseHeader`/`PhaseFooter`, `Badge`, max width containers).
 - Create realistic practice datasets in `public/resources/` and link with `<a href="/resources/file.csv" download>`.
 - Use existing interactive components; avoid inventing new APIs. If you add/modify components, immediately document them in the MCP knowledge base.
-- For testing and validation, prefer Chrome MCP tools and page navigation checks; avoid local build commands unless approved.
+- For testing and validation, prefer Chrome MCP tools and page navigation checks; run local builds only for the required `npm run build` verification step.
 
 ## Excel‑Focused Lesson Patterns (Active Work)
 The course uses a “textbook‑first” approach with interactive formative assessment. Two recurring Excel lessons per unit are common:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,20 +14,21 @@ Follow this process for every development slice to keep the repository, sprint a
 5. Branch from `main` using `<type>/<issue>-<slug>` (example: `feat/7-mcq-quiz-auto-score`). All commits for the slice stay on this branch.
 6. Practice TDD: add or update tests first, then implement. Run `npm run lint` and `npm run test` before every commit. When APIs or Prisma schema change, also run `npm run test:integration`; for broader flows, run `npm run test:e2e`.
 7. Use Conventional Commit messages (e.g., `feat: add automated scoring rubric`). Keep commits atomic and scoped to the issue.
-8. Push the branch (`git push -u origin <branch>`) and open a PR (`gh pr create --fill --label ... --milestone ...`). Link the issue, record test commands in the body, and run `gh pr checks`.
-9. Complete a self-review, address feedback on the same branch, then merge with squash (`gh pr merge --squash --delete-branch`). Ensure CI is green before merge.
-10. After merge, switch back to `main`, run `git pull --ff-only`, prune stale branches, close the linked issue (if not auto-closed), and update sprint artifacts (sprint doc, TODO.md) to reflect completion.
-11. Repeat the loop for the next prioritized issue; do not batch unrelated work on a single branch.
+8. Before final verification, terminate all running dev servers (e.g., `pkill -f "npm run dev"` or `pkill -f next`), then execute `npm run build`. Resolve any build errors before claiming the slice is complete.
+9. Push the branch (`git push -u origin <branch>`) and open a PR (`gh pr create --fill --label ... --milestone ...`). Link the issue, record test commands in the body, and run `gh pr checks`.
+10. Complete a self-review, address feedback on the same branch, then merge with squash (`gh pr merge --squash --delete-branch`). Ensure CI is green before merge.
+11. After merge, switch back to `main`, run `git pull --ff-only`, prune stale branches, close the linked issue (if not auto-closed), and update sprint artifacts (sprint doc, TODO.md) to reflect completion.
+12. Repeat the loop for the next prioritized issue; do not batch unrelated work on a single branch.
 
 ## Agent Operating Rules (Read First)
 - Work only in `bus-math-nextjs/` unless explicitly told otherwise.
-- Do NOT run `npm` commands (including `npm run build`, `npm run dev`, `npm start`, installs) or mutate `.next` without explicit user approval.
+- Avoid `npm` commands (including `npm run build`, `npm run dev`, `npm start`, installs) unless you are performing the mandatory final `npm run build` verification or have explicit user approval. Do not mutate `.next` manually.
 - Prefer fast, read‑only introspection: use `rg` (ripgrep) to search, and read files in chunks ≤250 lines.
 - Verify component exports before import: check for `export default` vs named exports in actual files.
 - Follow six‑phase page structure and the established styling wrapper from lesson03 (gradient background, `PhaseHeader`/`PhaseFooter`, `Badge`, max width containers).
 - Create realistic practice datasets in `public/resources/` and link with `<a href="/resources/file.csv" download>`.
 - Use existing interactive components; avoid inventing new APIs. If you add/modify components, immediately document them in the MCP knowledge base.
-- For testing and validation, prefer Chrome MCP tools and page navigation checks; avoid local build commands unless approved.
+- For testing and validation, prefer Chrome MCP tools and page navigation checks; run local builds only for the required `npm run build` verification step.
 
 ## Excel‑Focused Lesson Patterns (Active Work)
 The course uses a “textbook‑first” approach with interactive formative assessment. Two recurring Excel lessons per unit are common:

--- a/README.md
+++ b/README.md
@@ -302,12 +302,12 @@ npm run lint
 
 ### Testing & Quality Assurance
 
-**Browser Testing with Chrome MCP:**
+**Browser Testing with Chrome DevTools MCP:**
 ```bash
 # Test component functionality in real browser environment
-mcp__chrome-mcp-studio__chrome_navigate --url="http://localhost:3000/student/unit01/lesson01/phase-1"
-mcp__chrome-mcp-studio__chrome_get_interactive_elements  # Verify component accessibility
-mcp__chrome-mcp-studio__chrome_console  # Monitor for React errors
+mcp__chrome-devtools__navigate_page --url="http://localhost:3000/student/unit01/lesson01/phase-1"
+mcp__chrome-devtools__take_snapshot  # Verify component accessibility and interactive elements
+mcp__chrome-devtools__list_console_messages  # Monitor for React errors
 ```
 
 **Component Testing:**


### PR DESCRIPTION
## Summary
- Updated TDD workflow documentation to include mandatory production build verification
- Replaced chrome-mcp-studio references with chrome-devtools MCP server
- Added requirement to kill dev servers before final verification

## Changes
- **AGENTS.md & CLAUDE.md**: Added step 8 requiring `pkill` dev servers and `npm run build` before completion
- **README.md**: Updated Chrome MCP examples to use chrome-devtools API
- **All docs**: Removed all chrome-mcp-studio references (verified with ripgrep)

## Test Plan
- ✅ Verified `rg "chrome-mcp-studio"` returns no matches
- ✅ Killed running dev servers successfully
- ✅ Ran `npm run build` - compiled successfully in 67s with static export

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)