### PR TITLE
refactor: consume unit01 lessons 05-07 scenarios

### DIFF
--- a/bus-math-nextjs/src/app/student/unit01/lesson05/phase-1/page.tsx
+++ b/bus-math-nextjs/src/app/student/unit01/lesson05/phase-1/page.tsx
@@ -1,172 +1,117 @@
+import { ScenarioNarrative } from "@/components/student/ScenarioNarrative"
 import { PhaseHeader } from "@/components/student/PhaseHeader"
 import { PhaseFooter } from "@/components/student/PhaseFooter"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Badge } from "@/components/ui/badge"
 import ComprehensionCheck from "@/components/exercises/ComprehensionCheck"
-import { Users, AlertTriangle, Shield, Zap } from "lucide-react"
-import { lesson05Data, unit01Data, lesson05Phases } from "../lesson-data"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Users } from "lucide-react"
+import { getLessonScenario } from "@/data/scenarios"
+import {
+  adaptComprehensionCheck,
+  adaptTurnAndTalk,
+  getPhaseBySequence,
+  getPhaseComponent,
+  mapLessonMetadata,
+  mapScenarioPhasesToLessonPhases
+} from "@/adapters/scenario-to-props"
+import { unit01Data } from "../lesson-data"
 
-const currentPhase = lesson05Phases[0]
+const lessonScenario = getLessonScenario("unit01", 5)
+const phasesForHeader = mapScenarioPhasesToLessonPhases(lessonScenario)
+const lessonHeader = mapLessonMetadata(lessonScenario)
+const phaseScenario = getPhaseBySequence(lessonScenario, 1)
+const unitHeader = {
+  id: lessonScenario.metadata.unitId,
+  title: lessonScenario.metadata.unitTitle,
+  sequence: unit01Data.sequence
+}
 
-const hookQuestions = [
-  {
-    id: "q1",
-    question: "A client payment is posted with a missing AccountID. What should a robust model do?",
-    answers: [
-      "Flag the missing ID and prevent totals from updating silently",
-      "Ignore the row and keep totals unchanged",
-      "Guess the account based on description text",
-      "Hide the error to keep the sheet clean"
-    ],
-    explanation: "Investor-ready models surface problems clearly and never hide data issues."
-  },
-  {
-    id: "q2",
-    question: "Sarah switches from cash to accrual view. What should change?",
-    answers: [
-      "Recognition timing updates dynamically without breaking formulas",
-      "Only chart colors change",
-      "Nothing changes—method doesn't affect totals",
-      "The workbook requires manual copy-paste updates"
-    ],
-    explanation: "Dynamic method switching is a hallmark of professional automation."
-  },
-  {
-    id: "q3",
-    question: "Debit and credit totals disagree by $125. The right behavior is to:",
-    answers: [
-      "Show a visible Out-of-Balance warning and isolate the issue",
-      "Round totals to make them match",
-      "Delete the last row to reset the error",
-      "Export to PDF to lock the numbers"
-    ],
-    explanation: "A self-auditing ledger must highlight imbalances and help trace the cause."
-  }
-]
+const comprehensionComponent = getPhaseComponent(phaseScenario, "comprehensionCheck")
+if (!comprehensionComponent) {
+  throw new Error("Unit 01 Lesson 05 Phase 1 scenario is missing a comprehension check component.")
+}
+
+const turnAndTalkComponent = getPhaseComponent(phaseScenario, "turnAndTalk")
+if (!turnAndTalkComponent) {
+  throw new Error("Unit 01 Lesson 05 Phase 1 scenario is missing a turn and talk component.")
+}
+
+const comprehensionData = adaptComprehensionCheck(comprehensionComponent)
+const turnAndTalkData = adaptTurnAndTalk(turnAndTalkComponent)
 
 export default function Phase1Page() {
+  const currentPhase = phasesForHeader.find(phase => phase.sequence === phaseScenario.sequence)!
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 to-red-50">
       <PhaseHeader
-        lesson={lesson05Data}
-        unit={unit01Data}
+        lesson={lessonHeader}
+        unit={unitHeader}
         phase={currentPhase}
-        phases={lesson05Phases}
+        phases={phasesForHeader}
       />
 
       <main className="container mx-auto px-4 py-8 space-y-8">
         <section className="space-y-6">
           <div className="text-center space-y-4">
             <Badge className="bg-red-100 text-red-800 text-lg px-4 py-2">
-              🎯 Phase 1: Hook — Sarah’s Advanced Automation Stress Test
+              🎯 Phase {phaseScenario.sequence}: {phaseScenario.name}
             </Badge>
-            <h1 className="text-3xl font-bold text-gray-900">
-              Fragile vs. Robust: Can Sarah’s Ledger Survive Growth?
-            </h1>
+            <h1 className="text-3xl font-bold text-gray-900">{phaseScenario.title}</h1>
             <p className="text-lg text-gray-700 max-w-3xl mx-auto leading-relaxed">
-              Sarah’s TechStart Solutions is growing fast. New invoices, partial payments, and
-              refunds hit her books every week. A fragile spreadsheet breaks under this stress.
-              A robust, self-auditing model adapts and keeps investor trust.
+              {phaseScenario.summary}
             </p>
           </div>
         </section>
 
-        <section className="max-w-4xl mx-auto grid md:grid-cols-2 gap-6">
-          <Card className="border-red-200 bg-white">
+        <section className="max-w-4xl mx-auto space-y-8">
+          <ScenarioNarrative blocks={phaseScenario.narrative} />
+
+          <Card className="border-red-200 bg-red-50">
             <CardHeader>
-              <CardTitle className="text-red-700 flex items-center gap-2">
-                <AlertTriangle className="h-5 w-5" />
-                Fragile Build (Before)
+              <CardTitle className="text-red-800">
+                {comprehensionData.title ?? "Diagnostic Check"}
               </CardTitle>
             </CardHeader>
-            <CardContent className="text-sm text-red-800 space-y-2">
-              <ul className="list-disc list-inside space-y-1">
-                <li>Hard-coded totals that ignore new rows</li>
-                <li>No warning for missing AccountIDs</li>
-                <li>Manual method switching (cash vs. accrual)</li>
-                <li>Out-of-balance errors go unnoticed</li>
-                <li>Hidden mistakes damage investor confidence</li>
-              </ul>
+            <CardContent>
+              <ComprehensionCheck
+                questions={comprehensionData.questions}
+                title={comprehensionData.title}
+                description={comprehensionData.description ?? "Test your understanding"}
+                showExplanations={comprehensionData.showExplanations ?? true}
+                allowRetry={comprehensionData.allowRetry ?? true}
+              />
             </CardContent>
           </Card>
 
-          <Card className="border-green-200 bg-white">
-            <CardHeader>
-              <CardTitle className="text-green-700 flex items-center gap-2">
-                <Shield className="h-5 w-5" />
-                Robust Build (After)
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="text-sm text-green-800 space-y-2">
-              <ul className="list-disc list-inside space-y-1">
-                <li>Structured references update with new rows</li>
-                <li>XLOOKUP + IFERROR flags missing IDs</li>
-                <li>Dynamic method switch with clear labels</li>
-                <li>Trial balance control shows balance status</li>
-                <li>Professional documentation and audit trail</li>
-              </ul>
-            </CardContent>
-          </Card>
-        </section>
-
-        <section className="max-w-4xl mx-auto">
-          <ComprehensionCheck
-            title="Diagnostic: Advanced Automation Readiness"
-            description="Predict how a professional ledger should behave under stress."
-            questions={hookQuestions}
-            showExplanations={true}
-            allowRetry={true}
-          />
-        </section>
-
-        <section className="max-w-4xl mx-auto">
           <Card className="border-purple-200 bg-purple-50">
             <CardHeader>
               <CardTitle className="text-purple-800 flex items-center gap-2">
                 <Users className="h-5 w-5" />
-                Turn and Talk: Risk and Investor Trust
+                Turn and Talk: {turnAndTalkData.title}
               </CardTitle>
             </CardHeader>
-            <CardContent className="text-purple-800 space-y-2">
-              <p>
-                Sarah just learned her totals were off by $125 for two weeks. Discuss with a partner:
-              </p>
+            <CardContent className="text-purple-800 space-y-3">
+              <p className="font-medium">{turnAndTalkData.description}</p>
               <ul className="list-disc list-inside space-y-1">
-                <li>What business risks does this create?</li>
-                <li>What would convince an investor that her model is reliable?</li>
-                <li>Which safeguard would you build first, and why?</li>
+                {turnAndTalkData.prompts.map((prompt, idx) => (
+                  <li key={idx}>{prompt}</li>
+                ))}
               </ul>
               <div className="mt-3 p-3 bg-purple-100 rounded border border-purple-200 text-sm">
-                <strong className="mr-1">Goal:</strong> Name one control that prevents silent errors and
-                one control that speeds up reviews.
+                <strong className="mr-1">Duration:</strong> {turnAndTalkData.duration}
               </div>
-            </CardContent>
-          </Card>
-        </section>
-
-        <section className="max-w-4xl mx-auto">
-          <Card className="border-blue-200 bg-blue-50">
-            <CardHeader>
-              <CardTitle className="text-blue-800 flex items-center gap-2">
-                <Zap className="h-5 w-5" />
-                Why This Matters
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="text-blue-800">
-              A self-auditing ledger protects cash flow, prevents tax mistakes, and builds investor
-              confidence. Automation reduces closing time and frees Sarah to focus on clients.
             </CardContent>
           </Card>
         </section>
       </main>
 
-      <PhaseFooter 
-        lesson={lesson05Data}
-        unit={unit01Data}
+      <PhaseFooter
+        lesson={lessonHeader}
+        unit={unitHeader}
         phase={currentPhase}
-        phases={lesson05Phases}
+        phases={phasesForHeader}
       />
     </div>
   )
 }
-

--- a/bus-math-nextjs/src/app/student/unit01/lesson05/phase-2/page.tsx
+++ b/bus-math-nextjs/src/app/student/unit01/lesson05/phase-2/page.tsx
@@ -1,102 +1,85 @@
+import { ScenarioNarrative } from "@/components/student/ScenarioNarrative"
 import { PhaseHeader } from "@/components/student/PhaseHeader"
 import { PhaseFooter } from "@/components/student/PhaseFooter"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Badge } from "@/components/ui/badge"
 import FillInTheBlank from "@/components/exercises/FillInTheBlank"
-import { BookOpen, ListChecks } from "lucide-react"
-import { lesson05Data, unit01Data, lesson05Phases } from "../lesson-data"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent } from "@/components/ui/card"
+import { getLessonScenario } from "@/data/scenarios"
+import {
+  adaptFillInTheBlank,
+  getPhaseBySequence,
+  getPhaseComponent,
+  mapLessonMetadata,
+  mapScenarioPhasesToLessonPhases
+} from "@/adapters/scenario-to-props"
+import { unit01Data } from "../lesson-data"
 
-const currentPhase = lesson05Phases[1]
+const lessonScenario = getLessonScenario("unit01", 5)
+const phasesForHeader = mapScenarioPhasesToLessonPhases(lessonScenario)
+const lessonHeader = mapLessonMetadata(lessonScenario)
+const phaseScenario = getPhaseBySequence(lessonScenario, 2)
+const unitHeader = {
+  id: lessonScenario.metadata.unitId,
+  title: lessonScenario.metadata.unitTitle,
+  sequence: unit01Data.sequence
+}
 
-const vocabulary = [
-  { id: '1', text: 'Use {blank}(lookup_value, lookup_array, return_array, [if_not_found]) with IFERROR to handle missing AccountIDs', answer: 'XLOOKUP', hint: 'Modern lookup replacement for VLOOKUP/INDEX-MATCH' },
-  { id: '2', text: 'SUM totals by account using {blank}(sum_range, criteria_range1, criteria1, ...)', answer: 'SUMIFS', hint: 'Multi-criteria summation for posting checks' },
-  { id: '3', text: 'Avoid broken ranges by using {blank}[Column] instead of A2:A999', answer: 'Structured References', hint: 'Excel Tables keep formulas dynamic' },
-  { id: '4', text: 'Wrap lookups with {blank}(value, value_if_error) to prevent silent failures', answer: 'IFERROR', hint: 'Surface issues without crashing formulas' },
-  { id: '5', text: 'Create dropdowns and block invalid entries using Data {blank}', answer: 'Validation', hint: 'Lists, numbers, dates with rules' },
-  { id: '6', text: 'Switch recognition timing with a single cell toggle (Cash vs {blank})', answer: 'Accrual', hint: 'Method switching controlled by logic' },
-]
+const fillInBlankComponent = getPhaseComponent(phaseScenario, "fillInTheBlank")
+if (!fillInBlankComponent) {
+  throw new Error("Unit 01 Lesson 05 Phase 2 scenario is missing a fill-in-the-blank component.")
+}
+
+const fillInBlankData = adaptFillInTheBlank(fillInBlankComponent)
 
 export default function Phase2Page() {
+  const currentPhase = phasesForHeader.find(phase => phase.sequence === phaseScenario.sequence)!
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 to-green-50">
       <PhaseHeader
-        lesson={lesson05Data}
-        unit={unit01Data}
+        lesson={lessonHeader}
+        unit={unitHeader}
         phase={currentPhase}
-        phases={lesson05Phases}
+        phases={phasesForHeader}
       />
 
       <main className="container mx-auto px-4 py-8 space-y-8">
         <section className="space-y-6">
           <div className="text-center space-y-4">
             <Badge className="bg-green-100 text-green-800 text-lg px-4 py-2">
-              📚 Phase 2: Introduction — Professional-Grade Automation
+              📚 Phase {phaseScenario.sequence}: {phaseScenario.name}
             </Badge>
-            <h1 className="text-3xl font-bold text-gray-900">
-              XLOOKUP + SUMIFS + Structured References = Reliable Ledger
-            </h1>
+            <h1 className="text-3xl font-bold text-gray-900">{phaseScenario.title}</h1>
             <p className="text-lg text-gray-700 max-w-3xl mx-auto leading-relaxed">
-              Today you’ll build controls that catch mistakes before they spread. These tools
-              keep Sarah’s books accurate even as her business grows.
+              {phaseScenario.summary}
             </p>
           </div>
         </section>
 
-        <section className="max-w-4xl mx-auto space-y-4">
-          <Card className="border-blue-200 bg-blue-50">
-            <CardHeader>
-              <CardTitle className="text-blue-900 flex items-center gap-2">
-                <BookOpen className="h-5 w-5" />
-                Key Patterns and Exact Syntax
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="text-blue-900 space-y-3 text-sm leading-relaxed">
-              <p><strong>Account mapping with error handling:</strong> <code>=IFERROR(XLOOKUP([@AccountID], Accounts[AccountID], Accounts[AccountName], "Missing ID"), "Missing ID")</code></p>
-              <p><strong>Trial balance control:</strong> <code>=SUMIFS(Transactions[Debit], Transactions[AccountID], [@AccountID]) - SUMIFS(Transactions[Credit], Transactions[AccountID], [@AccountID])</code></p>
-              <p><strong>Out-of-balance flag:</strong> <code>=IF(SUM(Transactions[Debit])=SUM(Transactions[Credit]), "Balanced", "Out of Balance")</code></p>
-              <p><strong>Method switch (cash/accrual):</strong> Use a cell like <code>Settings[Method]</code> and <code>IF(Settings[@Method]="Cash", ReceivedDate, EarnedDate)</code> in calculations.</p>
+        <section className="max-w-4xl mx-auto space-y-8">
+          <ScenarioNarrative blocks={phaseScenario.narrative} />
+
+          <Card className="border-green-200 bg-green-50">
+            <CardContent className="pt-6">
+              <FillInTheBlank
+                sentences={fillInBlankData.sentences}
+                title={fillInBlankData.title}
+                description="Complete each sentence with the correct automation term."
+                showWordList={true}
+                randomizeWordOrder={true}
+                showHints={true}
+              />
             </CardContent>
           </Card>
-
-          <Card className="border-amber-200 bg-amber-50">
-            <CardHeader>
-              <CardTitle className="text-amber-900 flex items-center gap-2">
-                <ListChecks className="h-5 w-5" />
-                Professional Standards
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="text-amber-900 text-sm space-y-2">
-              <ul className="list-disc list-inside space-y-1">
-                <li>Use Tables with clear names and structured references</li>
-                <li>Document every control with a short note next to it</li>
-                <li>Never hide errors—surface them with plain language</li>
-                <li>Block bad input using Data Validation (lists, numbers, dates)</li>
-                <li>Test with edge cases before trusting results</li>
-              </ul>
-            </CardContent>
-          </Card>
-        </section>
-
-        <section className="max-w-4xl mx-auto">
-          <FillInTheBlank
-            sentences={vocabulary}
-            title="Advanced Vocabulary Check"
-            description="Fill in the key terms used to build professional, self-auditing ledgers."
-            showWordList={true}
-            randomizeWordOrder={true}
-            showHints={true}
-          />
         </section>
       </main>
 
-      <PhaseFooter 
-        lesson={lesson05Data}
-        unit={unit01Data}
+      <PhaseFooter
+        lesson={lessonHeader}
+        unit={unitHeader}
         phase={currentPhase}
-        phases={lesson05Phases}
+        phases={phasesForHeader}
       />
     </div>
   )
 }
-

--- a/bus-math-nextjs/src/app/student/unit01/lesson05/phase-3/page.tsx
+++ b/bus-math-nextjs/src/app/student/unit01/lesson05/phase-3/page.tsx
@@ -1,90 +1,69 @@
+import { ScenarioNarrative } from "@/components/student/ScenarioNarrative"
 import { PhaseHeader } from "@/components/student/PhaseHeader"
 import { PhaseFooter } from "@/components/student/PhaseFooter"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
+import { Card, CardContent } from "@/components/ui/card"
 import ErrorCheckingSystem from "@/components/business-simulations/ErrorCheckingSystem"
-import { Settings, Target, Workflow } from "lucide-react"
-import { lesson05Data, unit01Data, lesson05Phases } from "../lesson-data"
+import { getLessonScenario } from "@/data/scenarios"
+import {
+  getPhaseBySequence,
+  mapLessonMetadata,
+  mapScenarioPhasesToLessonPhases
+} from "@/adapters/scenario-to-props"
+import { unit01Data } from "../lesson-data"
 
-const currentPhase = lesson05Phases[2]
+const lessonScenario = getLessonScenario("unit01", 5)
+const phasesForHeader = mapScenarioPhasesToLessonPhases(lessonScenario)
+const lessonHeader = mapLessonMetadata(lessonScenario)
+const phaseScenario = getPhaseBySequence(lessonScenario, 3)
+const unitHeader = {
+  id: lessonScenario.metadata.unitId,
+  title: lessonScenario.metadata.unitTitle,
+  sequence: unit01Data.sequence
+}
 
 export default function Phase3Page() {
+  const currentPhase = phasesForHeader.find(phase => phase.sequence === phaseScenario.sequence)!
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 to-purple-50">
       <PhaseHeader
-        lesson={lesson05Data}
-        unit={unit01Data}
+        lesson={lessonHeader}
+        unit={unitHeader}
         phase={currentPhase}
-        phases={lesson05Phases}
+        phases={phasesForHeader}
       />
 
       <main className="container mx-auto px-4 py-8 space-y-8">
         <section className="space-y-6">
           <div className="text-center space-y-4">
             <Badge className="bg-purple-100 text-purple-800 text-lg px-4 py-2">
-              🔧 Phase 3: Guided Practice — Building Sarah’s System
+              🔧 Phase {phaseScenario.sequence}: {phaseScenario.name}
             </Badge>
-            <h1 className="text-3xl font-bold text-gray-900">
-              Posting Validator + Dynamic Trial Balance
-            </h1>
+            <h1 className="text-3xl font-bold text-gray-900">{phaseScenario.title}</h1>
             <p className="text-lg text-gray-700 max-w-3xl mx-auto leading-relaxed">
-              Follow these steps to build a reliable control system. Your goal is to catch
-              problems early and show clear, professional messages.
+              {phaseScenario.summary}
             </p>
           </div>
         </section>
 
-        <section className="max-w-4xl mx-auto space-y-4">
-          <Card className="border-gray-200">
-            <CardHeader>
-              <CardTitle className="text-gray-800 flex items-center gap-2">
-                <Workflow className="h-5 w-5" />
-                Step-by-Step Build
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="text-sm text-gray-800 space-y-2">
-              <ol className="list-decimal list-inside space-y-1">
-                <li>Create Tables: <strong>Transactions</strong>(Date, DocNo, AccountID, Debit, Credit, EarnedDate, ReceivedDate) and <strong>Accounts</strong>(AccountID, AccountName, Type).</li>
-                <li>Account mapping: <code>=IFERROR(XLOOKUP([@AccountID], Accounts[AccountID], Accounts[AccountName], "Missing ID"), "Missing ID")</code></li>
-                <li>Posting control: per account, compute <code>SUMIFS(Transactions[Debit], Transactions[AccountID], [@AccountID])</code> and credits; difference = should be 0.</li>
-                <li>Global trial balance: compare total debits vs credits. Show <em>Balanced</em> or <em>Out of Balance</em> with color.</li>
-                <li>Method switch: use a <strong>Settings</strong> Table with <em>Method</em>. Choose Cash vs Accrual to set recognition date.</li>
-                <li>Data validation: block negative amounts for Debit/Credit and enforce AccountID format (e.g., ACC###).</li>
-                <li>Document: add a short note next to each control explaining its purpose.</li>
-              </ol>
+        <section className="max-w-4xl mx-auto space-y-8">
+          <ScenarioNarrative blocks={phaseScenario.narrative} />
+
+          <Card className="border-purple-200 bg-purple-50">
+            <CardContent className="pt-6">
+              <ErrorCheckingSystem />
             </CardContent>
           </Card>
-
-          <Card className="border-green-200 bg-green-50">
-            <CardHeader>
-              <CardTitle className="text-green-900 flex items-center gap-2">
-                <Settings className="h-5 w-5" />
-                Safeguards and Gotchas
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="text-green-900 text-sm space-y-1">
-              <ul className="list-disc list-inside space-y-1">
-                <li>Always use Table columns; never fixed ranges that miss new rows.</li>
-                <li>Wrap lookups with IFERROR to show clear messages.</li>
-                <li>Test with missing IDs, stale dates, and duplicates.</li>
-                <li>Make warnings visible—do not hide with white text or filters.</li>
-              </ul>
-            </CardContent>
-          </Card>
-        </section>
-
-        <section className="max-w-4xl mx-auto">
-          <ErrorCheckingSystem />
         </section>
       </main>
 
-      <PhaseFooter 
-        lesson={lesson05Data}
-        unit={unit01Data}
+      <PhaseFooter
+        lesson={lessonHeader}
+        unit={unitHeader}
         phase={currentPhase}
-        phases={lesson05Phases}
+        phases={phasesForHeader}
       />
     </div>
   )
 }
-

--- a/bus-math-nextjs/src/app/student/unit01/lesson05/phase-4/page.tsx
+++ b/bus-math-nextjs/src/app/student/unit01/lesson05/phase-4/page.tsx
@@ -1,98 +1,86 @@
+import { ScenarioNarrative } from "@/components/student/ScenarioNarrative"
 import { PhaseHeader } from "@/components/student/PhaseHeader"
 import { PhaseFooter } from "@/components/student/PhaseFooter"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
-import { Download, CheckSquare, TrendingUp } from "lucide-react"
-import { lesson05Data, unit01Data, lesson05Phases } from "../lesson-data"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Download } from "lucide-react"
+import { getLessonScenario } from "@/data/scenarios"
+import {
+  getPhaseBySequence,
+  mapLessonMetadata,
+  mapScenarioPhasesToLessonPhases
+} from "@/adapters/scenario-to-props"
+import { unit01Data } from "../lesson-data"
 
-const currentPhase = lesson05Phases[3]
+const lessonScenario = getLessonScenario("unit01", 5)
+const phasesForHeader = mapScenarioPhasesToLessonPhases(lessonScenario)
+const lessonHeader = mapLessonMetadata(lessonScenario)
+const phaseScenario = getPhaseBySequence(lessonScenario, 4)
+const unitHeader = {
+  id: lessonScenario.metadata.unitId,
+  title: lessonScenario.metadata.unitTitle,
+  sequence: unit01Data.sequence
+}
+
+const dataset = phaseScenario.datasets?.[0]
 
 export default function Phase4Page() {
+  const currentPhase = phasesForHeader.find(phase => phase.sequence === phaseScenario.sequence)!
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 to-orange-50">
       <PhaseHeader
-        lesson={lesson05Data}
-        unit={unit01Data}
+        lesson={lessonHeader}
+        unit={unitHeader}
         phase={currentPhase}
-        phases={lesson05Phases}
+        phases={phasesForHeader}
       />
 
       <main className="container mx-auto px-4 py-8 space-y-8">
         <section className="space-y-6">
           <div className="text-center space-y-4">
             <Badge className="bg-orange-100 text-orange-800 text-lg px-4 py-2">
-              🚀 Phase 4: Independent Practice — Advanced Mastery Challenges
+              🚀 Phase {phaseScenario.sequence}: {phaseScenario.name}
             </Badge>
-            <h1 className="text-3xl font-bold text-gray-900">
-              Stress Test Your Automation with Real Edge Cases
-            </h1>
+            <h1 className="text-3xl font-bold text-gray-900">{phaseScenario.title}</h1>
             <p className="text-lg text-gray-700 max-w-3xl mx-auto leading-relaxed">
-              Download the dataset and implement your controls. Prove your ledger catches
-              issues and updates dynamically when rows change.
+              {phaseScenario.summary}
             </p>
           </div>
         </section>
 
-        <section className="max-w-4xl mx-auto space-y-4">
-          <Card className="border-blue-200 bg-blue-50">
-            <CardHeader>
-              <CardTitle className="text-blue-900 flex items-center gap-2">
-                <Download className="h-5 w-5" />
-                Advanced Practice Data
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="text-blue-900 text-sm">
-              <p className="mb-3">
-                Use this realistic CSV with mistakes and edge cases. Import into Excel and
-                build your <em>Transactions</em> and <em>Accounts</em> tables.
-              </p>
-              <a href="/resources/unit01-ledger-advanced-practice.csv" download className="underline text-blue-700">
-                Download: unit01-ledger-advanced-practice.csv
-              </a>
-            </CardContent>
-          </Card>
+        <section className="max-w-4xl mx-auto space-y-8">
+          {dataset && (
+            <Card className="border-blue-200 bg-blue-50">
+              <CardHeader>
+                <CardTitle className="text-blue-900 flex items-center gap-2">
+                  <Download className="h-5 w-5" />
+                  {dataset.title}
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="text-blue-900 text-sm">
+                <p className="mb-3">{dataset.description}</p>
+                <a
+                  href={dataset.path}
+                  download
+                  className="inline-block px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors"
+                >
+                  Download Dataset
+                </a>
+              </CardContent>
+            </Card>
+          )}
 
-          <Card className="border-green-200 bg-green-50">
-            <CardHeader>
-              <CardTitle className="text-green-900 flex items-center gap-2">
-                <CheckSquare className="h-5 w-5" />
-                Self-Assessment Checklist
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="text-green-900 text-sm space-y-1">
-              <ul className="list-disc list-inside space-y-1">
-                <li>Tables use structured references; totals auto-update with new rows</li>
-                <li>Missing AccountIDs show clear warnings (no silent failures)</li>
-                <li>Trial balance shows Balanced/Out of Balance accurately</li>
-                <li>Cash vs Accrual method switch works across calculations</li>
-                <li>Data Validation blocks negative amounts and stale dates</li>
-                <li>Short documentation notes explain each control’s purpose</li>
-              </ul>
-            </CardContent>
-          </Card>
-
-          <Card className="border-amber-200 bg-amber-50">
-            <CardHeader>
-              <CardTitle className="text-amber-900 flex items-center gap-2">
-                <TrendingUp className="h-5 w-5" />
-                Business Focus
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="text-amber-900 text-sm">
-              Tie your findings to cash flow and investor updates. If the model flags issues,
-              what actions should Sarah take before sending reports to a mentor or investor?
-            </CardContent>
-          </Card>
+          <ScenarioNarrative blocks={phaseScenario.narrative} />
         </section>
       </main>
 
-      <PhaseFooter 
-        lesson={lesson05Data}
-        unit={unit01Data}
+      <PhaseFooter
+        lesson={lessonHeader}
+        unit={unitHeader}
         phase={currentPhase}
-        phases={lesson05Phases}
+        phases={phasesForHeader}
       />
     </div>
   )
 }
-

--- a/bus-math-nextjs/src/app/student/unit01/lesson05/phase-5/page.tsx
+++ b/bus-math-nextjs/src/app/student/unit01/lesson05/phase-5/page.tsx
@@ -1,85 +1,83 @@
+import { ScenarioNarrative } from "@/components/student/ScenarioNarrative"
 import { PhaseHeader } from "@/components/student/PhaseHeader"
 import { PhaseFooter } from "@/components/student/PhaseFooter"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Badge } from "@/components/ui/badge"
 import ComprehensionCheck from "@/components/exercises/ComprehensionCheck"
-import { getUnit01Phase5ComprehensionCheckItems } from "@/data/question-banks/unit01-phase5"
-import { Award, Briefcase } from "lucide-react"
-import { lesson05Data, unit01Data, lesson05Phases } from "../lesson-data"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent } from "@/components/ui/card"
+import { getLessonScenario } from "@/data/scenarios"
+import {
+  adaptComprehensionCheck,
+  getPhaseBySequence,
+  getPhaseComponent,
+  mapLessonMetadata,
+  mapScenarioPhasesToLessonPhases
+} from "@/adapters/scenario-to-props"
+import { unit01Data } from "../lesson-data"
 
-const currentPhase = lesson05Phases[4]
-const assessmentQuestions = getUnit01Phase5ComprehensionCheckItems({ lessonIds: ["lesson05"] })
+const lessonScenario = getLessonScenario("unit01", 5)
+const phasesForHeader = mapScenarioPhasesToLessonPhases(lessonScenario)
+const lessonHeader = mapLessonMetadata(lessonScenario)
+const phaseScenario = getPhaseBySequence(lessonScenario, 5)
+const unitHeader = {
+  id: lessonScenario.metadata.unitId,
+  title: lessonScenario.metadata.unitTitle,
+  sequence: unit01Data.sequence
+}
+
+const comprehensionComponent = getPhaseComponent(phaseScenario, "comprehensionCheck")
+if (!comprehensionComponent) {
+  throw new Error("Unit 01 Lesson 05 Phase 5 scenario is missing a comprehension check component.")
+}
+
+const comprehensionData = adaptComprehensionCheck(comprehensionComponent)
 
 export default function Phase5Page() {
+  const currentPhase = phasesForHeader.find(phase => phase.sequence === phaseScenario.sequence)!
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 to-yellow-50">
       <PhaseHeader
-        lesson={lesson05Data}
-        unit={unit01Data}
+        lesson={lessonHeader}
+        unit={unitHeader}
         phase={currentPhase}
-        phases={lesson05Phases}
+        phases={phasesForHeader}
       />
 
       <main className="container mx-auto px-4 py-8 space-y-8">
         <section className="space-y-6">
           <div className="text-center space-y-4">
             <Badge className="bg-yellow-100 text-yellow-800 text-lg px-4 py-2">
-              📊 Phase 5: Assessment — Professional Mastery
+              📊 Phase {phaseScenario.sequence}: {phaseScenario.name}
             </Badge>
-            <h1 className="text-3xl font-bold text-gray-900">
-              Advanced Automation and Business Judgment
-            </h1>
+            <h1 className="text-3xl font-bold text-gray-900">{phaseScenario.title}</h1>
             <p className="text-lg text-gray-700 max-w-3xl mx-auto leading-relaxed">
-              Demonstrate technical skill and explain decisions that matter to investors.
+              {phaseScenario.summary}
             </p>
           </div>
         </section>
 
-        <section className="max-w-4xl mx-auto">
-          <ComprehensionCheck
-            title="Investor-Ready Ledger Assessment"
-            description="Answer all questions. Focus on reliability, clarity, and auditability."
-            questions={assessmentQuestions}
-            showExplanations={true}
-            allowRetry={true}
-          />
-        </section>
+        <section className="max-w-4xl mx-auto space-y-8">
+          <ScenarioNarrative blocks={phaseScenario.narrative} />
 
-        <section className="max-w-4xl mx-auto grid md:grid-cols-2 gap-6">
-          <Card className="border-green-200 bg-green-50">
-            <CardHeader>
-              <CardTitle className="text-green-900 flex items-center gap-2">
-                <Award className="h-5 w-5" />
-                Proficiency Standards
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="text-green-900 text-sm">
-              Investor-ready means your model updates dynamically, surfaces errors clearly, and
-              includes brief documentation beside each control. A reviewer can follow your logic
-              without guessing.
-            </CardContent>
-          </Card>
-          <Card className="border-blue-200 bg-blue-50">
-            <CardHeader>
-              <CardTitle className="text-blue-900 flex items-center gap-2">
-                <Briefcase className="h-5 w-5" />
-                Career Connection
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="text-blue-900 text-sm">
-              Analysts and consultants build automated checks every day. The habits you practice
-              here—structured references, validation, documentation—map directly to professional
-              workflows in finance and operations.
+          <Card className="border-yellow-200 bg-yellow-50">
+            <CardContent className="pt-6">
+              <ComprehensionCheck
+                title={comprehensionData.title ?? "Assessment"}
+                description={comprehensionData.description ?? "Test your mastery"}
+                questions={comprehensionData.questions}
+                showExplanations={comprehensionData.showExplanations ?? true}
+                allowRetry={comprehensionData.allowRetry ?? true}
+              />
             </CardContent>
           </Card>
         </section>
       </main>
 
-      <PhaseFooter 
-        lesson={lesson05Data}
-        unit={unit01Data}
+      <PhaseFooter
+        lesson={lessonHeader}
+        unit={unitHeader}
         phase={currentPhase}
-        phases={lesson05Phases}
+        phases={phasesForHeader}
       />
     </div>
   )

--- a/bus-math-nextjs/src/app/student/unit01/lesson05/phase-6/page.tsx
+++ b/bus-math-nextjs/src/app/student/unit01/lesson05/phase-6/page.tsx
@@ -1,91 +1,80 @@
+import { ScenarioNarrative } from "@/components/student/ScenarioNarrative"
 import { PhaseHeader } from "@/components/student/PhaseHeader"
 import { PhaseFooter } from "@/components/student/PhaseFooter"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Badge } from "@/components/ui/badge"
 import ReflectionJournal from "@/components/exercises/ReflectionJournal"
-import { Lightbulb } from "lucide-react"
-import { lesson05Data, unit01Data, lesson05Phases } from "../lesson-data"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent } from "@/components/ui/card"
+import { getLessonScenario } from "@/data/scenarios"
+import {
+  adaptReflection,
+  getPhaseBySequence,
+  getPhaseComponent,
+  mapLessonMetadata,
+  mapScenarioPhasesToLessonPhases
+} from "@/adapters/scenario-to-props"
+import { unit01Data } from "../lesson-data"
 
-const currentPhase = lesson05Phases[5]
+const lessonScenario = getLessonScenario("unit01", 5)
+const phasesForHeader = mapScenarioPhasesToLessonPhases(lessonScenario)
+const lessonHeader = mapLessonMetadata(lessonScenario)
+const phaseScenario = getPhaseBySequence(lessonScenario, 6)
+const unitHeader = {
+  id: lessonScenario.metadata.unitId,
+  title: lessonScenario.metadata.unitTitle,
+  sequence: unit01Data.sequence
+}
 
-const capPrompts = [
-  {
-    id: 'courage-adv',
-    category: 'courage' as const,
-    prompt: 'Describe a moment when your formulas failed. How did you face the uncertainty and keep going?',
-    placeholder: 'Explain what broke, how you felt, and your first step forward...'
-  },
-  {
-    id: 'adaptability-adv',
-    category: 'adaptability' as const,
-    prompt: 'What change did you make after testing edge cases (missing IDs, stale dates, negatives)?',
-    placeholder: 'Write about the specific adjustment and why it improved reliability...'
-  },
-  {
-    id: 'persistence-adv',
-    category: 'persistence' as const,
-    prompt: 'Which safeguard took the longest to get right? What kept you working until it was reliable?',
-    placeholder: 'Share the toughest step and your strategy to finish it...'
-  }
-]
+const reflectionComponent = getPhaseComponent(phaseScenario, "reflection")
+if (!reflectionComponent) {
+  throw new Error("Unit 01 Lesson 05 Phase 6 scenario is missing a reflection component.")
+}
+
+const reflectionData = adaptReflection(reflectionComponent)
 
 export default function Phase6Page() {
+  const currentPhase = phasesForHeader.find(phase => phase.sequence === phaseScenario.sequence)!
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 to-indigo-50">
       <PhaseHeader
-        lesson={lesson05Data}
-        unit={unit01Data}
+        lesson={lessonHeader}
+        unit={unitHeader}
         phase={currentPhase}
-        phases={lesson05Phases}
+        phases={phasesForHeader}
       />
 
       <main className="container mx-auto px-4 py-8 space-y-8">
         <section className="space-y-6">
           <div className="text-center space-y-4">
             <Badge className="bg-indigo-100 text-indigo-800 text-lg px-4 py-2">
-              🎯 Phase 6: Closing — Ready for the Next Step
+              🎯 Phase {phaseScenario.sequence}: {phaseScenario.name}
             </Badge>
-            <h1 className="text-3xl font-bold text-gray-900">
-              Advanced Automation: Wins, Reliability, and What’s Next
-            </h1>
+            <h1 className="text-3xl font-bold text-gray-900">{phaseScenario.title}</h1>
             <p className="text-lg text-gray-700 max-w-3xl mx-auto leading-relaxed">
-              You built a self-auditing ledger that handles growth. Your controls make errors
-              obvious and save time—key signals for investors and mentors.
+              {phaseScenario.summary}
             </p>
           </div>
         </section>
 
-        <section className="max-w-4xl mx-auto space-y-4">
-          <Card className="border-blue-200 bg-blue-50">
-            <CardHeader>
-              <CardTitle className="text-blue-900 flex items-center gap-2">
-                <Lightbulb className="h-5 w-5" />
-                Synthesis: What You Mastered
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="text-blue-900 text-sm">
-              You automated posting validation, handled missing IDs, and built a dynamic trial balance.
-              You documented controls and blocked bad inputs. These habits prepare you for Lesson06,
-              where you will connect these controls to dashboards and polished investor summaries.
-            </CardContent>
-          </Card>
-        </section>
+        <section className="max-w-4xl mx-auto space-y-8">
+          <ScenarioNarrative blocks={phaseScenario.narrative} />
 
-        <section className="max-w-4xl mx-auto">
-          <ReflectionJournal 
-            unitTitle="Unit 1 — Advanced Ledger Automation Reflection"
-            prompts={capPrompts}
-          />
-        </section>
+          <Card className="border-indigo-200 bg-indigo-50">
+            <CardContent className="pt-6">
+              <ReflectionJournal
+                unitTitle={reflectionData.unitTitle}
+                prompts={reflectionData.prompts}
+              />
+            </CardContent>
+          </Card>        </section>
       </main>
 
-      <PhaseFooter 
-        lesson={lesson05Data}
-        unit={unit01Data}
+      <PhaseFooter
+        lesson={lessonHeader}
+        unit={unitHeader}
         phase={currentPhase}
-        phases={lesson05Phases}
+        phases={phasesForHeader}
       />
     </div>
   )
 }
-

--- a/bus-math-nextjs/src/app/student/unit01/lesson06/phase-1/page.tsx
+++ b/bus-math-nextjs/src/app/student/unit01/lesson06/phase-1/page.tsx
@@ -1,89 +1,76 @@
+import { ScenarioNarrative } from "@/components/student/ScenarioNarrative"
 import { PhaseHeader } from "@/components/student/PhaseHeader"
 import { PhaseFooter } from "@/components/student/PhaseFooter"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Badge } from "@/components/ui/badge"
 import ComprehensionCheck from "@/components/exercises/ComprehensionCheck"
-import { Users, AlertTriangle, MonitorSmartphone } from "lucide-react"
-// Import dashboard directly; it's a client component with its own boundary
-// This avoids using next/dynamic with ssr:false in a Server Component
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Users, MonitorSmartphone } from "lucide-react"
 import { FinancialDashboard } from "@/components/charts/FinancialDashboard"
-import { lesson06Data, unit01Data, lesson06Phases } from "../lesson-data"
+import { getLessonScenario } from "@/data/scenarios"
+import {
+  adaptComprehensionCheck,
+  adaptTurnAndTalk,
+  getPhaseBySequence,
+  getPhaseComponent,
+  mapLessonMetadata,
+  mapScenarioPhasesToLessonPhases
+} from "@/adapters/scenario-to-props"
+import { unit01Data } from "../lesson-data"
 
-const currentPhase = lesson06Phases[0]
+const lessonScenario = getLessonScenario("unit01", 6)
+const phasesForHeader = mapScenarioPhasesToLessonPhases(lessonScenario)
+const lessonHeader = mapLessonMetadata(lessonScenario)
+const phaseScenario = getPhaseBySequence(lessonScenario, 1)
+const unitHeader = {
+  id: lessonScenario.metadata.unitId,
+  title: lessonScenario.metadata.unitTitle,
+  sequence: unit01Data.sequence
+}
 
-// Note: FinancialDashboard is a client component ('use client' in file)
-// Importing it directly from this Server Component is supported by Next.js
+const comprehensionComponent = getPhaseComponent(phaseScenario, "comprehensionCheck")
+if (!comprehensionComponent) {
+  throw new Error("Unit 01 Lesson 06 Phase 1 scenario is missing a comprehension check component.")
+}
 
-const hookQuestions = [
-  {
-    id: "q1",
-    question: "Sarah needs a single dashboard that switches Base/Stretch/Downside by name. What is the safest lookup setting?",
-    answers: [
-      "Exact match (0/FALSE) with IFNA/IFERROR",
-      "Approximate match (1/TRUE) for faster speed",
-      "Wildcard match so any spelling works",
-      "No lookup—hard‑code each chart to a tab"
-    ],
-    explanation: "Dashboards must be stable. Use exact match plus IFNA/IFERROR to prevent silent failures."
-  },
-  {
-    id: "q2",
-    question: "A chart stops updating when Sarah adds new rows. What likely caused it?",
-    answers: [
-      "Chart points to a static A2:A20 range, not a Table column",
-      "Excel can only show 20 rows in a chart",
-      "The dataset must be sorted A→Z to refresh",
-      "The sheet tab name changed and breaks all charts"
-    ],
-    explanation: "Bind charts to Tables/structured references so ranges expand automatically."
-  },
-  {
-    id: "q3",
-    question: "An investor asks, ‘What should we do if margin drops below 20%?’ What belongs on Sarah’s dashboard?",
-    answers: [
-      "A clear KPI card and an executive summary note tied to the threshold",
-      "Hidden calculations so the dashboard stays simple",
-      "Ten tabs of supporting math for later reading",
-      "A one‑time screenshot pasted into a slide deck"
-    ],
-    explanation: "Decision‑ready dashboards pair KPIs with plain‑language guidance at key thresholds."
-  }
-]
+const turnAndTalkComponent = getPhaseComponent(phaseScenario, "turnAndTalk")
+if (!turnAndTalkComponent) {
+  throw new Error("Unit 01 Lesson 06 Phase 1 scenario is missing a turn and talk component.")
+}
 
-export default function Unit01Lesson06Phase1() {
+const comprehensionData = adaptComprehensionCheck(comprehensionComponent)
+const turnAndTalkData = adaptTurnAndTalk(turnAndTalkComponent)
+
+export default function Phase1Page() {
+  const currentPhase = phasesForHeader.find(phase => phase.sequence === phaseScenario.sequence)!
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 to-red-50">
       <PhaseHeader
-        lesson={lesson06Data}
-        unit={unit01Data}
+        lesson={lessonHeader}
+        unit={unitHeader}
         phase={currentPhase}
-        phases={lesson06Phases}
+        phases={phasesForHeader}
       />
 
       <main className="container mx-auto px-4 py-8 space-y-8">
         <section className="space-y-6">
           <div className="text-center space-y-4">
             <Badge className="bg-red-100 text-red-800 text-lg px-4 py-2">
-              📊 Phase 1: Hook — Sarah’s Live Dashboard Demo
+              📊 Phase {phaseScenario.sequence}: {phaseScenario.name}
             </Badge>
-            <h1 className="text-3xl font-bold text-gray-900">
-              From Hard‑Coded Tabs to Integrated, Decision‑Ready Dashboards
-            </h1>
-            <p className="text-lg text-gray-700 max-w-4xl mx-auto leading-relaxed">
-              A real client asks Sarah for one clean view with scenario toggles and clear
-              decision cues. Her old workbook uses separate sheets for each case. It breaks.
-              The integrated version uses a driver table, exact‑match lookups, and charts that
-              expand automatically.
+            <h1 className="text-3xl font-bold text-gray-900">{phaseScenario.title}</h1>
+            <p className="text-lg text-gray-700 max-w-3xl mx-auto leading-relaxed">
+              {phaseScenario.summary}
             </p>
           </div>
         </section>
 
-        <section className="max-w-4xl mx-auto grid gap-6">
+        <section className="max-w-4xl mx-auto space-y-8">
           <Card className="border-blue-200 bg-white">
             <CardHeader>
               <CardTitle className="text-blue-800 flex items-center gap-2">
                 <MonitorSmartphone className="h-5 w-5" />
-                Live Preview: Investor‑Ready Dashboard
+                Live Preview: Investor-Ready Dashboard
               </CardTitle>
             </CardHeader>
             <CardContent>
@@ -91,30 +78,21 @@ export default function Unit01Lesson06Phase1() {
             </CardContent>
           </Card>
 
-          <Card className="border-red-200 bg-red-50">
+          <ScenarioNarrative blocks={phaseScenario.narrative} />
+
+          <Card className="border-blue-200 bg-blue-50">
             <CardHeader>
-              <CardTitle className="text-red-800 flex items-center gap-2">
-                <AlertTriangle className="h-5 w-5" />
-                Before vs After
+              <CardTitle className="text-blue-800">
+                {comprehensionData.title ?? "Dashboard Design Check"}
               </CardTitle>
             </CardHeader>
-            <CardContent className="text-sm text-red-900 space-y-2">
-              <ul className="list-disc list-inside space-y-1">
-                <li><strong>Before:</strong> Hard‑coded ranges; charts miss new rows; manual tab switching</li>
-                <li><strong>After:</strong> Named driver table; XLOOKUP exact‑match; charts bound to Table columns</li>
-                <li><strong>Result:</strong> Fast scenario toggles, clear KPIs, and investor trust</li>
-              </ul>
-            </CardContent>
-          </Card>
-
-          <Card className="border-gray-200">
             <CardContent>
               <ComprehensionCheck
-                title="Integration Pitfalls and Dashboard Best Practices"
-                description="Predict stable build choices that make dashboards decision‑ready."
-                questions={hookQuestions}
-                showExplanations={true}
-                allowRetry={true}
+                questions={comprehensionData.questions}
+                title={comprehensionData.title}
+                description={comprehensionData.description ?? "Test your understanding"}
+                showExplanations={comprehensionData.showExplanations ?? true}
+                allowRetry={comprehensionData.allowRetry ?? true}
               />
             </CardContent>
           </Card>
@@ -123,28 +101,29 @@ export default function Unit01Lesson06Phase1() {
             <CardHeader>
               <CardTitle className="text-purple-800 flex items-center gap-2">
                 <Users className="h-5 w-5" />
-                Turn and Talk: Clarity Under Pressure
+                Turn and Talk: {turnAndTalkData.title}
               </CardTitle>
             </CardHeader>
-            <CardContent className="text-purple-900 space-y-2 text-sm">
-              <p>
-                Sarah has 2 minutes to explain a downside result. Discuss with a partner:
-              </p>
+            <CardContent className="text-purple-800 space-y-3">
+              <p className="font-medium">{turnAndTalkData.description}</p>
               <ul className="list-disc list-inside space-y-1">
-                <li>Which KPIs should she show first, and why?</li>
-                <li>How do scenario names help decision‑makers compare quickly?</li>
-                <li>What one sentence should appear in the executive summary?</li>
+                {turnAndTalkData.prompts.map((prompt, idx) => (
+                  <li key={idx}>{prompt}</li>
+                ))}
               </ul>
+              <div className="mt-3 p-3 bg-purple-100 rounded border border-purple-200 text-sm">
+                <strong className="mr-1">Duration:</strong> {turnAndTalkData.duration}
+              </div>
             </CardContent>
           </Card>
         </section>
       </main>
 
-      <PhaseFooter 
-        lesson={lesson06Data}
-        unit={unit01Data}
+      <PhaseFooter
+        lesson={lessonHeader}
+        unit={unitHeader}
         phase={currentPhase}
-        phases={lesson06Phases}
+        phases={phasesForHeader}
       />
     </div>
   )

--- a/bus-math-nextjs/src/app/student/unit01/lesson06/phase-2/page.tsx
+++ b/bus-math-nextjs/src/app/student/unit01/lesson06/phase-2/page.tsx
@@ -1,111 +1,84 @@
+import { ScenarioNarrative } from "@/components/student/ScenarioNarrative"
 import { PhaseHeader } from "@/components/student/PhaseHeader"
 import { PhaseFooter } from "@/components/student/PhaseFooter"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Badge } from "@/components/ui/badge"
 import FillInTheBlank from "@/components/exercises/FillInTheBlank"
-import { BookOpen, ListChecks } from "lucide-react"
-import { lesson06Data, unit01Data, lesson06Phases } from "../lesson-data"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent } from "@/components/ui/card"
+import { getLessonScenario } from "@/data/scenarios"
+import {
+  adaptFillInTheBlank,
+  getPhaseBySequence,
+  getPhaseComponent,
+  mapLessonMetadata,
+  mapScenarioPhasesToLessonPhases
+} from "@/adapters/scenario-to-props"
+import { unit01Data } from "../lesson-data"
 
-const currentPhase = lesson06Phases[1]
+const lessonScenario = getLessonScenario("unit01", 6)
+const phasesForHeader = mapScenarioPhasesToLessonPhases(lessonScenario)
+const lessonHeader = mapLessonMetadata(lessonScenario)
+const phaseScenario = getPhaseBySequence(lessonScenario, 2)
+const unitHeader = {
+  id: lessonScenario.metadata.unitId,
+  title: lessonScenario.metadata.unitTitle,
+  sequence: unit01Data.sequence
+}
 
-const vocab = [
-  { id: '1', text: 'Use a {blank} (or Scenario Manager) to store Base/Stretch/Downside drivers', answer: 'driver table', hint: 'A small named table that feeds the model' },
-  { id: '2', text: 'Bind charts to {blank} so ranges expand with new rows', answer: 'structured references', hint: 'Table[Column] instead of A2:A999' },
-  { id: '3', text: 'Switch scenarios by name with XLOOKUP set to {blank} match', answer: 'exact', hint: 'MATCH 0 in INDEX/MATCH or FALSE in VLOOKUP' },
-  { id: '4', text: 'Wrap lookups with {blank} or IFNA to avoid silent errors', answer: 'IFERROR', hint: 'Provide friendly messages' },
-  { id: '5', text: 'Protect decision speed with clear {blank} like margin, runway, and cash days', answer: 'KPIs', hint: 'Key Performance Indicators' },
-  { id: '6', text: 'Flag outdated reports: compare AsOfDate to {blank}()', answer: 'TODAY', hint: 'Stale dates reduce trust' },
-]
+const fillInBlankComponent = getPhaseComponent(phaseScenario, "fillInTheBlank")
+if (!fillInBlankComponent) {
+  throw new Error("Unit 01 Lesson 06 Phase 2 scenario is missing a fill-in-the-blank component.")
+}
 
-export default function Unit01Lesson06Phase2() {
+const fillInBlankData = adaptFillInTheBlank(fillInBlankComponent)
+
+export default function Phase2Page() {
+  const currentPhase = phasesForHeader.find(phase => phase.sequence === phaseScenario.sequence)!
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 to-green-50">
       <PhaseHeader
-        lesson={lesson06Data}
-        unit={unit01Data}
+        lesson={lessonHeader}
+        unit={unitHeader}
         phase={currentPhase}
-        phases={lesson06Phases}
+        phases={phasesForHeader}
       />
 
       <main className="container mx-auto px-4 py-8 space-y-8">
         <section className="space-y-6">
           <div className="text-center space-y-4">
             <Badge className="bg-green-100 text-green-800 text-lg px-4 py-2">
-              📚 Phase 2: Introduction — From Model to Decision
+              📚 Phase {phaseScenario.sequence}: {phaseScenario.name}
             </Badge>
-            <h1 className="text-3xl font-bold text-gray-900">
-              Scenarios by Name, Charts that Stay Linked, KPIs that Speak
-            </h1>
-            <p className="text-lg text-gray-700 max-w-4xl mx-auto leading-relaxed">
-              You will wire a single driver table to control the whole model. XLOOKUP with
-              exact match and IFNA/IFERROR makes switching stable. Charts read Table columns,
-              not fixed ranges. Your KPIs turn numbers into decisions.
+            <h1 className="text-3xl font-bold text-gray-900">{phaseScenario.title}</h1>
+            <p className="text-lg text-gray-700 max-w-3xl mx-auto leading-relaxed">
+              {phaseScenario.summary}
             </p>
           </div>
         </section>
 
-        <section className="max-w-4xl mx-auto space-y-4">
-          <Card className="border-blue-200 bg-blue-50">
-            <CardHeader>
-              <CardTitle className="text-blue-900 flex items-center gap-2">
-                <BookOpen className="h-5 w-5" />
-                Exact Syntax Patterns
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="text-sm text-blue-900 space-y-2">
-              <p>
-                <strong>Driver pull (scenario by name):</strong>
-                <code className="ml-2">=IFNA(XLOOKUP(Settings[@Scenario], Drivers[Scenario], Drivers[Price], "Missing Scenario"), "Missing Scenario")</code>
-              </p>
-              <p>
-                <strong>INDEX/MATCH exact alternative:</strong>
-                <code className="ml-2">=IFNA(INDEX(Drivers[Price], MATCH(Settings[@Scenario], Drivers[Scenario], 0)), "Missing Scenario")</code>
-              </p>
-              <p>
-                <strong>Chart binding:</strong>
-                Use <code>Table[Column]</code> references so charts expand as data grows.
-              </p>
-              <p>
-                <strong>Stale date flag:</strong>
-                <code className="ml-2">=IF(Settings[@AsOfDate] &lt; TODAY()-7, "Stale AsOfDate", "Fresh")</code>
-              </p>
+        <section className="max-w-4xl mx-auto space-y-8">
+          <ScenarioNarrative blocks={phaseScenario.narrative} />
+
+          <Card className="border-green-200 bg-green-50">
+            <CardContent className="pt-6">
+              <FillInTheBlank
+                sentences={fillInBlankData.sentences}
+                title={fillInBlankData.title}
+                description="Complete each sentence with the correct integration term."
+                showWordList={true}
+                randomizeWordOrder={true}
+                showHints={true}
+              />
             </CardContent>
           </Card>
-
-          <Card className="border-gray-200">
-            <CardHeader>
-              <CardTitle className="text-gray-900 flex items-center gap-2">
-                <ListChecks className="h-5 w-5" />
-                Professional Standards
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="text-sm text-gray-800 space-y-1">
-              <ul className="list-disc list-inside space-y-1">
-                <li>Single source of truth: one named driver table</li>
-                <li>Exact‑match lookups with IFNA/IFERROR guarding every switch</li>
-                <li>Charts bound to Table columns; no static A1:A20 references</li>
-                <li>Validation on inputs: block negative rates and &gt;100% percentages</li>
-                <li>Short documentation note next to each control (purpose + expected behavior)</li>
-              </ul>
-            </CardContent>
-          </Card>
-
-          <FillInTheBlank 
-            sentences={vocab}
-            title="Vocabulary: Integration & Dashboards"
-            description="Reinforce the exact language used to build reliable scenario dashboards."
-            showWordList={true}
-            randomizeWordOrder={true}
-            showHints={true}
-          />
         </section>
       </main>
 
-      <PhaseFooter 
-        lesson={lesson06Data}
-        unit={unit01Data}
+      <PhaseFooter
+        lesson={lessonHeader}
+        unit={unitHeader}
         phase={currentPhase}
-        phases={lesson06Phases}
+        phases={phasesForHeader}
       />
     </div>
   )

--- a/bus-math-nextjs/src/app/student/unit01/lesson06/phase-3/page.tsx
+++ b/bus-math-nextjs/src/app/student/unit01/lesson06/phase-3/page.tsx
@@ -1,238 +1,72 @@
+import { ScenarioNarrative } from "@/components/student/ScenarioNarrative"
 import { PhaseHeader } from "@/components/student/PhaseHeader"
 import { PhaseFooter } from "@/components/student/PhaseFooter"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import ComprehensionCheck from "@/components/exercises/ComprehensionCheck"
 import ErrorCheckingSystem from "@/components/business-simulations/ErrorCheckingSystem"
+import { ShieldAlert, Users } from "lucide-react"
+import { getLessonScenario } from "@/data/scenarios"
 import {
-  ArrowRightCircle,
-  Calculator,
-  Lightbulb,
-  Settings,
-  ShieldAlert,
-  Users,
-  Workflow
-} from "lucide-react"
-import { lesson06Data, unit01Data, lesson06Phases } from "../lesson-data"
+  adaptComprehensionCheck,
+  adaptTurnAndTalk,
+  getPhaseBySequence,
+  getPhaseComponent,
+  mapLessonMetadata,
+  mapScenarioPhasesToLessonPhases
+} from "@/adapters/scenario-to-props"
+import { unit01Data } from "../lesson-data"
 
-const currentPhase = lesson06Phases[2]
+const lessonScenario = getLessonScenario("unit01", 6)
+const phasesForHeader = mapScenarioPhasesToLessonPhases(lessonScenario)
+const lessonHeader = mapLessonMetadata(lessonScenario)
+const phaseScenario = getPhaseBySequence(lessonScenario, 3)
+const unitHeader = {
+  id: lessonScenario.metadata.unitId,
+  title: lessonScenario.metadata.unitTitle,
+  sequence: unit01Data.sequence
+}
 
-const guidedPracticeQuestions = [
-  {
-    id: "scenario-lookup",
-    question:
-      "Why do we wrap our XLOOKUP formula in IFNA when we pull the Price from the Drivers table?",
-    answers: [
-      "It shows a friendly message if the scenario name is mistyped or missing.",
-      "It makes the lookup run faster than normal.",
-      "It allows approximate matches for new scenarios.",
-      "It turns the result into a chart automatically."
-    ],
-    explanation:
-      "IFNA catches errors so students see a plain-language note instead of a raw Excel error. That supports professional model QA."
-  },
-  {
-    id: "structured-references",
-    question:
-      "Sarah wants her charts to stay linked when she adds a new scenario row. What should she do when she creates formulas?",
-    answers: [
-      "Use structured references like Drivers[Volume] so Excel expands ranges automatically.",
-      "Copy the current cell references and lock them with dollar signs.",
-      "Convert the table back to a normal range before charting.",
-      "Type the numbers by hand into the chart setup."
-    ],
-    explanation:
-      "Structured references follow the table even as it grows, so the visuals update with every new scenario."
-  },
-  {
-    id: "cash-days",
-    question:
-      "If AR Days are 32 and AP Days are 24, what should the Cash Days formula return, and what does it tell Sarah?",
-    answers: [
-      "8 cash days, meaning money waits 8 days longer to arrive than it takes to leave.",
-      "56 cash days, because you add the two numbers together to see the gap.",
-      "0 cash days, because the numbers cancel each other out.",
-      "-8 cash days, showing Sarah collects cash 8 days faster than she pays vendors."
-    ],
-    explanation:
-      "Cash Days = AR Days – AP Days, so 32 – 24 = 8. A positive number warns Sarah that cash is tied up before expenses are paid."
-  }
-]
+const comprehensionComponent = getPhaseComponent(phaseScenario, "comprehensionCheck")
+if (!comprehensionComponent) {
+  throw new Error("Unit 01 Lesson 06 Phase 3 scenario is missing a comprehension check component.")
+}
 
-export default function Unit01Lesson06Phase3() {
+const turnAndTalkComponent = getPhaseComponent(phaseScenario, "turnAndTalk")
+if (!turnAndTalkComponent) {
+  throw new Error("Unit 01 Lesson 06 Phase 3 scenario is missing a turn and talk component.")
+}
+
+const comprehensionData = adaptComprehensionCheck(comprehensionComponent)
+const turnAndTalkData = adaptTurnAndTalk(turnAndTalkComponent)
+
+export default function Phase3Page() {
+  const currentPhase = phasesForHeader.find(phase => phase.sequence === phaseScenario.sequence)!
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 to-purple-50">
       <PhaseHeader
-        lesson={lesson06Data}
-        unit={unit01Data}
+        lesson={lessonHeader}
+        unit={unitHeader}
         phase={currentPhase}
-        phases={lesson06Phases}
+        phases={phasesForHeader}
       />
 
       <main className="container mx-auto px-4 py-8 space-y-8">
         <section className="space-y-6">
           <div className="text-center space-y-4">
             <Badge className="bg-purple-100 text-purple-800 text-lg px-4 py-2">
-              🔧 Phase 3: Guided Practice — Build the Integration
+              🔧 Phase {phaseScenario.sequence}: {phaseScenario.name}
             </Badge>
-            <h1 className="text-3xl font-bold text-gray-900">
-              Guide Sarah’s Scenario Switchboard in Excel
-            </h1>
+            <h1 className="text-3xl font-bold text-gray-900">{phaseScenario.title}</h1>
             <p className="text-lg text-gray-700 max-w-4xl mx-auto leading-relaxed">
-              Sarah Chen is prepping an investor update for TechStart Solutions. She needs a
-              scenario dropdown that pulls clean numbers, powers live charts, and warns her when
-              the model drifts away from targets. Follow these steps to coach her through the build.
+              {phaseScenario.summary}
             </p>
           </div>
         </section>
 
         <section className="max-w-4xl mx-auto space-y-6">
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-gray-900 flex items-center gap-2">
-                <Workflow className="h-5 w-5" />
-                Step 1 — Wire the Scenario Controls
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="text-gray-800 space-y-4 leading-relaxed">
-              <p>
-                Import <strong>unit01-ledger-integration-practice.csv</strong> as a table named{' '}
-                <strong>Drivers</strong>. The first three rows (Base, Stretch, Downside) are Sarah’s main
-                scenarios. The rows below the divider are “edge cases” you will use later to test
-                validation.
-              </p>
-              <ol className="list-decimal list-inside space-y-2 text-base">
-                <li>
-                  On a sheet called <strong>Settings</strong>, place <strong>Selected_Scenario</strong> in B2. Create a
-                  dropdown list that points to <code>=Drivers[Scenario]</code>. This powers the entire model.
-                </li>
-                <li>
-                  In the <strong>Model</strong> sheet, pull each driver with XLOOKUP. Example:
-                  <code className="block bg-purple-100 text-purple-900 px-3 py-2 rounded">
-                    =IFNA(XLOOKUP(Settings!B2, Drivers[Scenario], Drivers[Price]), "Type a scenario name from Drivers")
-                  </code>
-                  Repeat for unit cost, volume, AR Days, AP Days, overhead, and targets.
-                </li>
-                <li>
-                  Keep every formula in structured-reference form. If Sarah inserts Base2 or a new
-                  investor case, your links will still work.
-                </li>
-              </ol>
-              <div className="bg-purple-100 border border-purple-200 rounded-lg p-4 text-purple-900 flex gap-3">
-                <Lightbulb className="h-6 w-6 flex-shrink-0" />
-                <p className="text-base">
-                  Student coach tip: ask your partner to mistype “Stretch” as “Strech.” If IFNA returns the
-                  helper message, your scenario switch is investor ready.
-                </p>
-              </div>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-gray-900 flex items-center gap-2">
-                <Calculator className="h-5 w-5" />
-                Step 2 — Build the Calculation Engine
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="text-gray-800 space-y-4 leading-relaxed">
-              <p>
-                Translate each driver into a live KPI. Remind students the math tells TechStart if the
-                plan protects cash or puts runway at risk.
-              </p>
-              <div className="space-y-4">
-                <Card className="bg-white border border-slate-200">
-                  <CardHeader className="pb-2">
-                    <CardTitle className="text-slate-900 text-lg flex items-center gap-2">
-                      <ArrowRightCircle className="h-5 w-5" /> Revenue and Margin
-                    </CardTitle>
-                  </CardHeader>
-                  <CardContent className="space-y-3 text-sm text-slate-800">
-                    <p>
-                      <strong>Revenue</strong> shows how much money comes in before costs.
-                    </p>
-                    <pre className="bg-slate-100 p-3 rounded text-slate-900 text-sm overflow-x-auto">
-=[@Price] * [@Volume]
-                    </pre>
-                    <p>
-                      <strong>Gross Margin %</strong> compares profit to sales. It drives the investor summary.
-                    </p>
-                    <pre className="bg-slate-100 p-3 rounded text-slate-900 text-sm overflow-x-auto">
-=(([@Price]*[@Volume]) - ([@UnitCost]*[@Volume]) - [@Overhead]) / ([@Price]*[@Volume])
-                    </pre>
-                  </CardContent>
-                </Card>
-                <Card className="bg-white border border-slate-200">
-                  <CardHeader className="pb-2">
-                    <CardTitle className="text-slate-900 text-lg flex items-center gap-2">
-                      <ArrowRightCircle className="h-5 w-5" /> Runway and Cash Days
-                    </CardTitle>
-                  </CardHeader>
-                  <CardContent className="space-y-3 text-sm text-slate-800">
-                    <p>
-                      <strong>Runway (months)</strong> estimates how long TechStart can cover overhead with the
-                      current margin cushion.
-                    </p>
-                    <pre className="bg-slate-100 p-3 rounded text-slate-900 text-sm overflow-x-auto">
-=([@Revenue] * [@Margin_Pct]) / [@Overhead]
-                    </pre>
-                    <p>
-                      <strong>Cash Days</strong> compares cash-in timing to cash-out timing.
-                    </p>
-                    <pre className="bg-slate-100 p-3 rounded text-slate-900 text-sm overflow-x-auto">
-=[@AR_Days] - [@AP_Days]
-                    </pre>
-                    <div className="bg-indigo-50 border border-indigo-200 rounded-lg p-3 text-indigo-900">
-                      <p className="font-semibold">Why This Matters</p>
-                      <p>
-                        Positive Cash Days mean money leaves before it returns. Investors want to see Sarah
-                        shrinking that gap or proving she can handle it.
-                      </p>
-                    </div>
-                  </CardContent>
-                </Card>
-              </div>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-gray-900 flex items-center gap-2">
-                <Settings className="h-5 w-5" />
-                Step 3 — Layer on Live Feedback
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="text-gray-800 space-y-4 leading-relaxed">
-              <p>
-                Students should prove the model guards against mistakes and communicates clearly.
-              </p>
-              <ul className="list-disc list-inside space-y-2 text-base">
-                <li>
-                  Build <strong>Data Validation</strong> alerts: stale <code>AsOfDate</code>, negative costs, AR above 90 days.
-                </li>
-                <li>
-                  Set conditional formatting tiles: green when Margin % ≥ Target, amber when Cash Days exceeds the target.
-                </li>
-                <li>
-                  Write an <strong>Executive Summary</strong> formula (e.g., nested IF) that snaps to the latest KPI
-                  story in one short sentence.
-                </li>
-                <li>
-                  Connect charts to the Drivers table so they refresh the instant a student switches scenarios.
-                </li>
-              </ul>
-              <div className="bg-emerald-50 border border-emerald-200 rounded-lg p-4 text-emerald-900 flex gap-3">
-                <Users className="h-6 w-6 flex-shrink-0" />
-                <div>
-                  <p className="font-semibold">Think-Pair-Share (3 minutes)</p>
-                  <p>
-                    Partner A tests the dropdown and reads the executive sentence aloud. Partner B double-checks the validation flags.
-                    Swap roles and note one improvement you would make before presenting to an investor.
-                  </p>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
+          <ScenarioNarrative blocks={phaseScenario.narrative} />
 
           <Card className="border-amber-200 bg-amber-50">
             <CardHeader>
@@ -249,20 +83,41 @@ export default function Unit01Lesson06Phase3() {
             </CardContent>
           </Card>
 
+          <Card className="border-green-200 bg-green-50">
+            <CardHeader>
+              <CardTitle className="text-green-800 flex items-center gap-2">
+                <Users className="h-5 w-5" />
+                Turn and Talk: {turnAndTalkData.title}
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="text-green-800 space-y-3">
+              <p className="font-medium">{turnAndTalkData.description}</p>
+              <ul className="list-disc list-inside space-y-1">
+                {turnAndTalkData.prompts.map((prompt, idx) => (
+                  <li key={idx}>{prompt}</li>
+                ))}
+              </ul>
+              <div className="mt-3 p-3 bg-green-100 rounded border border-green-200 text-sm">
+                <strong className="mr-1">Duration:</strong> {turnAndTalkData.duration}
+              </div>
+            </CardContent>
+          </Card>
+
           <ComprehensionCheck
-            title="Check Your Guided Practice"
-            description="Confirm you can explain the heart of Sarah’s scenario switchboard before moving on."
-            questions={guidedPracticeQuestions}
-            showExplanations
+            questions={comprehensionData.questions}
+            title={comprehensionData.title}
+            description={comprehensionData.description ?? "Test your understanding"}
+            showExplanations={comprehensionData.showExplanations ?? true}
+            allowRetry={comprehensionData.allowRetry ?? true}
           />
         </section>
       </main>
 
       <PhaseFooter
-        lesson={lesson06Data}
-        unit={unit01Data}
+        lesson={lessonHeader}
+        unit={unitHeader}
         phase={currentPhase}
-        phases={lesson06Phases}
+        phases={phasesForHeader}
       />
     </div>
   )

--- a/bus-math-nextjs/src/app/student/unit01/lesson06/phase-4/page.tsx
+++ b/bus-math-nextjs/src/app/student/unit01/lesson06/phase-4/page.tsx
@@ -1,267 +1,115 @@
+import { ScenarioNarrative } from "@/components/student/ScenarioNarrative"
 import { PhaseHeader } from "@/components/student/PhaseHeader"
 import { PhaseFooter } from "@/components/student/PhaseFooter"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import ComprehensionCheck from "@/components/exercises/ComprehensionCheck"
 import ReflectionJournal from "@/components/exercises/ReflectionJournal"
+import { Download } from "lucide-react"
+import { getLessonScenario } from "@/data/scenarios"
 import {
-  CheckCircle2,
-  ClipboardList,
-  Download,
-  FileText,
-  Gauge,
-  Target
-} from "lucide-react"
-import { lesson06Data, unit01Data, lesson06Phases } from "../lesson-data"
+  adaptComprehensionCheck,
+  adaptReflection,
+  getPhaseBySequence,
+  getPhaseComponent,
+  mapLessonMetadata,
+  mapScenarioPhasesToLessonPhases
+} from "@/adapters/scenario-to-props"
+import { unit01Data } from "../lesson-data"
 
-const currentPhase = lesson06Phases[3]
+const lessonScenario = getLessonScenario("unit01", 6)
+const phasesForHeader = mapScenarioPhasesToLessonPhases(lessonScenario)
+const lessonHeader = mapLessonMetadata(lessonScenario)
+const phaseScenario = getPhaseBySequence(lessonScenario, 4)
+const unitHeader = {
+  id: lessonScenario.metadata.unitId,
+  title: lessonScenario.metadata.unitTitle,
+  sequence: unit01Data.sequence
+}
 
-const independentPracticeQuestions = [
-  {
-    id: "scenario-switch",
-    question:
-      "After importing the CSV, what is the very first feature you should build so every other part of the workbook responds to the same choice?",
-    answers: [
-      "Create the Selected_Scenario dropdown that reads Drivers[Scenario].",
-      "Insert the revenue chart because visuals motivate the team.",
-      "Write the executive summary sentence so you know the tone.",
-      "Format the Drivers table with colors before doing formulas."
-    ],
-    explanation:
-      "The dropdown controls every lookup. Without it, the rest of the workbook cannot respond to scenario changes."
-  },
-  {
-    id: "validation",
-    question:
-      "Sarah tests an edge case with a negative UnitCost. What should happen in a finished model?",
-    answers: [
-      "A validation flag should appear so she knows the data is unsafe to present.",
-      "The workbook should ignore the row and keep yesterday's numbers.",
-      "Excel should close automatically because the input is not real.",
-      "Nothing should happen because negatives are impossible to prevent."
-    ],
-    explanation:
-      "Professional models do not hide bad data. They surface it quickly so the analyst can decide what to fix."
-  },
-  {
-    id: "summary",
-    question:
-      "Which detail belongs in Sarah’s one-sentence investor summary?",
-    answers: [
-      "A clear callout of the key KPI compared to its target.",
-      "The full list of every formula in the workbook.",
-      "A step-by-step guide for adding chart titles.",
-      "Personal feelings about how fun the assignment was."
-    ],
-    explanation:
-      "Investors want signal, not noise. Mention the KPI, the target, and the next action in one tight sentence."
-  }
-]
+const comprehensionComponent = getPhaseComponent(phaseScenario, "comprehensionCheck")
+if (!comprehensionComponent) {
+  throw new Error("Unit 01 Lesson 06 Phase 4 scenario is missing a comprehension check component.")
+}
 
-const reflectionPrompts = [
-  {
-    id: "courage-scenario",
-    category: "courage" as const,
-    prompt:
-      "Where did you have to take a risk or try a new Excel skill while wiring the scenario switchboard?",
-    placeholder: "Describe the exact step that felt bold (for example, writing IFNA around XLOOKUP)..."
-  },
-  {
-    id: "adaptability-flags",
-    category: "adaptability" as const,
-    prompt:
-      "What validation warning surprised you during testing, and how did you adjust the model to respond?",
-    placeholder: "Explain how the flag helped you catch an issue and the change you made..."
-  },
-  {
-    id: "persistence-summary",
-    category: "persistence" as const,
-    prompt:
-      "When your executive summary sentence did not read clearly at first, what revisions did you make to keep going?",
-    placeholder: "Share the edits you tried and how you kept the message data-driven..."
-  }
-]
+const reflectionComponent = getPhaseComponent(phaseScenario, "reflection")
+if (!reflectionComponent) {
+  throw new Error("Unit 01 Lesson 06 Phase 4 scenario is missing a reflection component.")
+}
 
-export default function Unit01Lesson06Phase4() {
+const comprehensionData = adaptComprehensionCheck(comprehensionComponent)
+const reflectionData = adaptReflection(reflectionComponent)
+const dataset = phaseScenario.datasets?.[0]
+
+export default function Phase4Page() {
+  const currentPhase = phasesForHeader.find(phase => phase.sequence === phaseScenario.sequence)!
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 to-orange-50">
       <PhaseHeader
-        lesson={lesson06Data}
-        unit={unit01Data}
+        lesson={lessonHeader}
+        unit={unitHeader}
         phase={currentPhase}
-        phases={lesson06Phases}
+        phases={phasesForHeader}
       />
 
       <main className="container mx-auto px-4 py-8 space-y-8">
         <section className="space-y-6">
           <div className="text-center space-y-4">
             <Badge className="bg-orange-100 text-orange-800 text-lg px-4 py-2">
-              🚀 Phase 4: Independent Practice — Integration Mastery Challenges
+              🚀 Phase {phaseScenario.sequence}: {phaseScenario.name}
             </Badge>
-            <h1 className="text-3xl font-bold text-gray-900">
-              Build Sarah’s Investor-Ready Scenario Switchboard
-            </h1>
+            <h1 className="text-3xl font-bold text-gray-900">{phaseScenario.title}</h1>
             <p className="text-lg text-gray-700 max-w-4xl mx-auto leading-relaxed">
-              Now it is your turn to lead the build. Combine the Drivers table, scenario dropdown,
-              calculations, charts, and validation into one workbook Sarah can show to investors in under a minute.
+              {phaseScenario.summary}
             </p>
           </div>
         </section>
 
         <section className="max-w-4xl mx-auto space-y-6">
-          <Card className="border-blue-200 bg-blue-50">
-            <CardHeader>
-              <CardTitle className="text-blue-900 flex items-center gap-2">
-                <Download className="h-5 w-5" />
-                Integration Dataset
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="text-blue-900 space-y-3 leading-relaxed">
-              <p>
-                Start with the authentic practice data Sarah collected. Import it as an Excel Table named
-                <strong> Drivers</strong>. Every row represents a full scenario ready for analysis.
-              </p>
-              <a
-                href="/resources/unit01-ledger-integration-practice.csv"
-                download
-                className="inline-flex items-center gap-2 font-semibold underline text-blue-700"
-              >
-                Download: unit01-ledger-integration-practice.csv
-              </a>
-              <p>
-                The edge-case rows (MissingScenario, Typo-Case, stale dates) exist to stress-test your
-                validation logic. Do not delete them—use them.
-              </p>
-            </CardContent>
-          </Card>
+          {dataset && (
+            <Card className="border-blue-200 bg-blue-50">
+              <CardHeader>
+                <CardTitle className="text-blue-900 flex items-center gap-2">
+                  <Download className="h-5 w-5" />
+                  {dataset.title}
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="text-blue-900 space-y-3 leading-relaxed">
+                <p>{dataset.description}</p>
+                <a
+                  href={dataset.path}
+                  download
+                  className="inline-flex items-center gap-2 font-semibold underline text-blue-700"
+                >
+                  Download: {dataset.path.split('/').pop() ?? 'dataset.csv'}
+                </a>
+              </CardContent>
+            </Card>
+          )}
 
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-gray-900 flex items-center gap-2">
-                <ClipboardList className="h-5 w-5" />
-                Independent Build Steps
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="text-gray-800 space-y-4 leading-relaxed">
-              <ol className="list-decimal list-inside space-y-2 text-base">
-                <li>
-                  <strong>Settings Sheet</strong>: Create <code>Selected_Scenario</code> (B2) with Data Validation pointing to
-                  <code>=Drivers[Scenario]</code>. Add a note reminding users that names are case-sensitive.
-                </li>
-                <li>
-                  <strong>Model Sheet</strong>: Use XLOOKUP+IFNA to pull price, unit cost, volume, AR/AP days, overhead,
-                  and target thresholds into a clean input block.
-                </li>
-                <li>
-                  <strong>KPIs</strong>: Calculate Revenue, Margin %, Cash Days, and Runway in their own section. Reference
-                  the pulled inputs with structured names (no A1:C10).
-                </li>
-                <li>
-                  <strong>Visuals</strong>: Insert a clustered column chart comparing scenarios and KPI cards (large numbers)
-                  that update the moment the dropdown changes.
-                </li>
-                <li>
-                  <strong>Validation + Flags</strong>: Build messages for missing scenario, stale AsOfDate, negative costs,
-                  and AR Days &gt; 90. Color-code them so investors see the status quickly.
-                </li>
-                <li>
-                  <strong>Executive Summary</strong>: Craft a one-sentence formula using IF statements. Mention the KPI,
-                  the target, and the recommended action when targets are missed.
-                </li>
-              </ol>
-              <div className="bg-orange-100 border border-orange-200 rounded-lg p-4 text-orange-900 flex gap-3">
-                <Gauge className="h-6 w-6 flex-shrink-0" />
-                <p>
-                  Quick test: switch to the Typo-Case scenario. If your summary warns about the missing name and your charts
-                  do not crash, your wiring is strong.
-                </p>
-              </div>
-            </CardContent>
-          </Card>
-
-          <Card className="border-green-200 bg-green-50">
-            <CardHeader>
-              <CardTitle className="text-green-900 flex items-center gap-2">
-                <CheckCircle2 className="h-5 w-5" />
-                Investor-Ready Quality Checklist
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="text-green-900 space-y-2 leading-relaxed">
-              <ul className="list-disc list-inside space-y-2 text-base">
-                <li>Scenario switching by name works and shows a human-readable warning when it fails.</li>
-                <li>Charts and KPI tiles refresh instantly with every scenario change or new row.</li>
-                <li>Validation flags catch stale dates, negative costs, and AR Days above 90.</li>
-                <li>Margin % and Cash Days are compared to their targets with clear OK/Beyond Target language.</li>
-                <li>All formulas use tables or named ranges; no hard-coded cell coordinates.</li>
-                <li>The executive summary names the KPI, cites the target, and offers an action verb.</li>
-              </ul>
-            </CardContent>
-          </Card>
-
-          <Card className="border-amber-200 bg-amber-50">
-            <CardHeader>
-              <CardTitle className="text-amber-900 flex items-center gap-2">
-                <FileText className="h-5 w-5" />
-                Executive Summary Inspiration
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="text-amber-900 space-y-3 leading-relaxed">
-              <p>
-                Investors read for signal, not story time. Use these sentence stems to stay focused:
-              </p>
-              <ul className="list-disc list-inside space-y-1 text-base">
-                <li>
-                  <strong>When targets are met</strong>: “Stretch scenario holds <strong>{"{Margin%}"}</strong> above the{' '}
-                  <strong>{"{Target}"}</strong>, so keep marketing spend steady.”
-                </li>
-                <li>
-                  <strong>When targets miss</strong>: “Downside cash gap is <strong>{"{CashDays}"}</strong> days (goal{' '}
-                  <strong>{"{Target}"}</strong>). Delay vendor payments 5 days and monitor collections daily.”
-                </li>
-              </ul>
-              <p>
-                Challenge yourself to keep the sentence under 25 words. Investors should understand the risk and your suggested fix at a glance.
-              </p>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-gray-900 flex items-center gap-2">
-                <Target className="h-5 w-5" />
-                Stretch Yourself
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="text-gray-800 space-y-3 leading-relaxed">
-              <p>
-                Ready for the next level? Duplicate the Model sheet and add a waterfall chart that shows how revenue drops to margin after each cost layer. Use the
-                same dropdown so both sheets stay in sync.
-              </p>
-              <p>
-                Bonus idea: create a slicer or timeline so Sarah can filter scenarios by AsOfDate when she loads future data.
-              </p>
-            </CardContent>
-          </Card>
+          <ScenarioNarrative blocks={phaseScenario.narrative} />
 
           <ComprehensionCheck
-            title="Quick Self-Check"
-            description="Make sure you understand the must-have features before you call the model complete."
-            questions={independentPracticeQuestions}
-            showExplanations
+            questions={comprehensionData.questions}
+            title={comprehensionData.title}
+            description={comprehensionData.description ?? "Test your understanding"}
+            showExplanations={comprehensionData.showExplanations ?? true}
+            allowRetry={comprehensionData.allowRetry ?? true}
           />
 
           <ReflectionJournal
-            unitTitle="Scenario Switchboard Reflection"
-            prompts={reflectionPrompts}
+            unitTitle={reflectionData.unitTitle}
+            prompts={reflectionData.prompts}
           />
         </section>
       </main>
 
       <PhaseFooter
-        lesson={lesson06Data}
-        unit={unit01Data}
+        lesson={lessonHeader}
+        unit={unitHeader}
         phase={currentPhase}
-        phases={lesson06Phases}
+        phases={phasesForHeader}
       />
     </div>
   )

--- a/bus-math-nextjs/src/app/student/unit01/lesson06/phase-5/page.tsx
+++ b/bus-math-nextjs/src/app/student/unit01/lesson06/phase-5/page.tsx
@@ -1,3 +1,4 @@
+import { ScenarioNarrative } from "@/components/student/ScenarioNarrative"
 import { PhaseHeader } from "@/components/student/PhaseHeader"
 import { PhaseFooter } from "@/components/student/PhaseFooter"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -5,37 +6,54 @@ import { Badge } from "@/components/ui/badge"
 import ComprehensionCheck from "@/components/exercises/ComprehensionCheck"
 import { getUnit01Phase5ComprehensionCheckItems } from "@/data/question-banks/unit01-phase5"
 import { Award, Briefcase } from "lucide-react"
-import { lesson06Data, unit01Data, lesson06Phases } from "../lesson-data"
+import { getLessonScenario } from "@/data/scenarios"
+import {
+  getPhaseBySequence,
+  mapLessonMetadata,
+  mapScenarioPhasesToLessonPhases
+} from "@/adapters/scenario-to-props"
+import { unit01Data } from "../lesson-data"
 
-const currentPhase = lesson06Phases[4]
+const lessonScenario = getLessonScenario("unit01", 6)
+const phasesForHeader = mapScenarioPhasesToLessonPhases(lessonScenario)
+const lessonHeader = mapLessonMetadata(lessonScenario)
+const phaseScenario = getPhaseBySequence(lessonScenario, 5)
+const unitHeader = {
+  id: lessonScenario.metadata.unitId,
+  title: lessonScenario.metadata.unitTitle,
+  sequence: unit01Data.sequence
+}
+
 const assessmentQuestions = getUnit01Phase5ComprehensionCheckItems({ lessonIds: ["lesson06"] })
 
-export default function Unit01Lesson06Phase5() {
+export default function Phase5Page() {
+  const currentPhase = phasesForHeader.find(phase => phase.sequence === phaseScenario.sequence)!
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 to-yellow-50">
       <PhaseHeader
-        lesson={lesson06Data}
-        unit={unit01Data}
+        lesson={lessonHeader}
+        unit={unitHeader}
         phase={currentPhase}
-        phases={lesson06Phases}
+        phases={phasesForHeader}
       />
 
       <main className="container mx-auto px-4 py-8 space-y-8">
         <section className="space-y-6">
           <div className="text-center space-y-4">
             <Badge className="bg-yellow-100 text-yellow-800 text-lg px-4 py-2">
-              ✅ Phase 5: Assessment — Integration & Dashboard Mastery
+              ✅ Phase {phaseScenario.sequence}: {phaseScenario.name}
             </Badge>
-            <h1 className="text-3xl font-bold text-gray-900">
-              Switching Logic, Chart Linkage, and Decision Framing
-            </h1>
+            <h1 className="text-3xl font-bold text-gray-900">{phaseScenario.title}</h1>
             <p className="text-lg text-gray-700 max-w-4xl mx-auto leading-relaxed">
-              Demonstrate both technical accuracy and applied business judgment.
+              {phaseScenario.summary}
             </p>
           </div>
         </section>
 
-        <section className="max-w-4xl mx-auto">
+        <section className="max-w-4xl mx-auto space-y-6">
+          <ScenarioNarrative blocks={phaseScenario.narrative} />
+
           <ComprehensionCheck
             title="Integration & Dashboard Mastery Check"
             description="Answer all questions. Focus on clarity, reliability, and auditability."
@@ -43,41 +61,41 @@ export default function Unit01Lesson06Phase5() {
             showExplanations={true}
             allowRetry={true}
           />
-        </section>
 
-        <section className="max-w-4xl mx-auto grid md:grid-cols-2 gap-6">
-          <Card className="border-green-200 bg-green-50">
-            <CardHeader>
-              <CardTitle className="text-green-900 flex items-center gap-2">
-                <Award className="h-5 w-5" />
-                Performance Standards
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="text-green-900 text-sm">
-              Investor‑ready dashboards present one place to decide: scenario toggles by name,
-              live visuals, clear thresholds, and complete safeguards.
-            </CardContent>
-          </Card>
-          <Card className="border-blue-200 bg-blue-50">
-            <CardHeader>
-              <CardTitle className="text-blue-900 flex items-center gap-2">
-                <Briefcase className="h-5 w-5" />
-                Career Connection
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="text-blue-900 text-sm">
-              Analysts and consultants build scenario dashboards to guide decisions. Your
-              build maps directly to client work: scenarios → insights → recommendations.
-            </CardContent>
-          </Card>
+          <div className="grid md:grid-cols-2 gap-6">
+            <Card className="border-green-200 bg-green-50">
+              <CardHeader>
+                <CardTitle className="text-green-900 flex items-center gap-2">
+                  <Award className="h-5 w-5" />
+                  Performance Standards
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="text-green-900 text-sm">
+                Investor‑ready dashboards present one place to decide: scenario toggles by name,
+                live visuals, clear thresholds, and complete safeguards.
+              </CardContent>
+            </Card>
+            <Card className="border-blue-200 bg-blue-50">
+              <CardHeader>
+                <CardTitle className="text-blue-900 flex items-center gap-2">
+                  <Briefcase className="h-5 w-5" />
+                  Career Connection
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="text-blue-900 text-sm">
+                Analysts and consultants build scenario dashboards to guide decisions. Your
+                build maps directly to client work: scenarios → insights → recommendations.
+              </CardContent>
+            </Card>
+          </div>
         </section>
       </main>
 
-      <PhaseFooter 
-        lesson={lesson06Data}
-        unit={unit01Data}
+      <PhaseFooter
+        lesson={lessonHeader}
+        unit={unitHeader}
         phase={currentPhase}
-        phases={lesson06Phases}
+        phases={phasesForHeader}
       />
     </div>
   )

--- a/bus-math-nextjs/src/app/student/unit01/lesson06/phase-6/page.tsx
+++ b/bus-math-nextjs/src/app/student/unit01/lesson06/phase-6/page.tsx
@@ -1,40 +1,65 @@
+import { ScenarioNarrative } from "@/components/student/ScenarioNarrative"
 import { PhaseHeader } from "@/components/student/PhaseHeader"
 import { PhaseFooter } from "@/components/student/PhaseFooter"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import ReflectionJournal from "@/components/exercises/ReflectionJournal"
 import { Lightbulb } from "lucide-react"
-import { lesson06Data, unit01Data, lesson06Phases } from "../lesson-data"
+import { getLessonScenario } from "@/data/scenarios"
+import {
+  adaptReflection,
+  getPhaseBySequence,
+  getPhaseComponent,
+  mapLessonMetadata,
+  mapScenarioPhasesToLessonPhases
+} from "@/adapters/scenario-to-props"
+import { unit01Data } from "../lesson-data"
 
-const currentPhase = lesson06Phases[5]
+const lessonScenario = getLessonScenario("unit01", 6)
+const phasesForHeader = mapScenarioPhasesToLessonPhases(lessonScenario)
+const lessonHeader = mapLessonMetadata(lessonScenario)
+const phaseScenario = getPhaseBySequence(lessonScenario, 6)
+const unitHeader = {
+  id: lessonScenario.metadata.unitId,
+  title: lessonScenario.metadata.unitTitle,
+  sequence: unit01Data.sequence
+}
 
-export default function Unit01Lesson06Phase6() {
+const reflectionComponent = getPhaseComponent(phaseScenario, "reflection")
+if (!reflectionComponent) {
+  throw new Error("Unit 01 Lesson 06 Phase 6 scenario is missing a reflection component.")
+}
+
+const reflectionData = adaptReflection(reflectionComponent)
+
+export default function Phase6Page() {
+  const currentPhase = phasesForHeader.find(phase => phase.sequence === phaseScenario.sequence)!
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 to-indigo-50">
       <PhaseHeader
-        lesson={lesson06Data}
-        unit={unit01Data}
+        lesson={lessonHeader}
+        unit={unitHeader}
         phase={currentPhase}
-        phases={lesson06Phases}
+        phases={phasesForHeader}
       />
 
       <main className="container mx-auto px-4 py-8 space-y-8">
         <section className="space-y-6">
           <div className="text-center space-y-4">
             <Badge className="bg-indigo-100 text-indigo-800 text-lg px-4 py-2">
-              🧭 Phase 6: Closing — Present with Confidence
+              🧭 Phase {phaseScenario.sequence}: {phaseScenario.name}
             </Badge>
-            <h1 className="text-3xl font-bold text-gray-900">
-              Integrated Automation: Your Best One‑Minute Story
-            </h1>
+            <h1 className="text-3xl font-bold text-gray-900">{phaseScenario.title}</h1>
             <p className="text-lg text-gray-700 max-w-4xl mx-auto leading-relaxed">
-              Summarize what changed: faster switching, stable charts, clear KPIs, and better
-              decisions. Prepare a short script you could use in a live investor call.
+              {phaseScenario.summary}
             </p>
           </div>
         </section>
 
-        <section className="max-w-4xl mx-auto space-y-4">
+        <section className="max-w-4xl mx-auto space-y-6">
+          <ScenarioNarrative blocks={phaseScenario.narrative} />
+
           <Card className="border-amber-200 bg-amber-50">
             <CardHeader>
               <CardTitle className="text-amber-900 flex items-center gap-2">
@@ -48,20 +73,19 @@ export default function Unit01Lesson06Phase6() {
               professional models.
             </CardContent>
           </Card>
-        </section>
 
-        <section className="max-w-4xl mx-auto">
-          <ReflectionJournal 
-            unitTitle="CAP Reflection — Integration & Dashboards"
+          <ReflectionJournal
+            unitTitle={reflectionData.unitTitle}
+            prompts={reflectionData.prompts}
           />
         </section>
       </main>
 
-      <PhaseFooter 
-        lesson={lesson06Data}
-        unit={unit01Data}
+      <PhaseFooter
+        lesson={lessonHeader}
+        unit={unitHeader}
         phase={currentPhase}
-        phases={lesson06Phases}
+        phases={phasesForHeader}
       />
     </div>
   )

--- a/bus-math-nextjs/src/app/student/unit01/lesson07/phase-1/page.tsx
+++ b/bus-math-nextjs/src/app/student/unit01/lesson07/phase-1/page.tsx
@@ -1,142 +1,115 @@
-'use client'
-
+import { ScenarioNarrative } from "@/components/student/ScenarioNarrative"
 import { PhaseHeader } from "@/components/student/PhaseHeader"
 import { PhaseFooter } from "@/components/student/PhaseFooter"
-import { lesson07Data, unit01Data, lesson07Phases } from "../lesson-data"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Badge } from "@/components/ui/badge"
-import { AlertTriangle, CheckCircle, XCircle, Target, Users } from "lucide-react"
 import ComprehensionCheck from "@/components/exercises/ComprehensionCheck"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Users } from "lucide-react"
+import { getLessonScenario } from "@/data/scenarios"
+import {
+  adaptComprehensionCheck,
+  adaptTurnAndTalk,
+  getPhaseBySequence,
+  getPhaseComponent,
+  mapLessonMetadata,
+  mapScenarioPhasesToLessonPhases
+} from "@/adapters/scenario-to-props"
+import { unit01Data } from "../lesson-data"
 
-const currentPhase = lesson07Phases[0]
+const lessonScenario = getLessonScenario("unit01", 7)
+const phasesForHeader = mapScenarioPhasesToLessonPhases(lessonScenario)
+const lessonHeader = mapLessonMetadata(lessonScenario)
+const phaseScenario = getPhaseBySequence(lessonScenario, 1)
+const unitHeader = {
+  id: lessonScenario.metadata.unitId,
+  title: lessonScenario.metadata.unitTitle,
+  sequence: unit01Data.sequence
+}
 
-const standardsQuiz = [
-  {
-    id: "std-1",
-    question: "In an investor-ready model, which lookup approach is correct?",
-    answers: [
-      "Use XLOOKUP (or INDEX/MATCH) with exact match and wrap with IFNA",
-      "Use VLOOKUP with approximate match for speed",
-      "Type values by hand to avoid formula errors",
-      "Use OFFSET with volatile recalculation"
-    ],
-    explanation: "Professional models require exact-match lookups and clear error handling (IFNA/IFERROR)."
-  },
-  {
-    id: "std-2",
-    question: "Charts should reference which kind of ranges?",
-    answers: [
-      "Tables/structured references so visuals auto-expand",
-      "Static ranges (A1:C10) for stability",
-      "Hidden sheets with copied numbers",
-      "Manual values entered into the chart"
-    ],
-    explanation: "Charts bound to structured references update as data grows and reduce maintenance risk."
-  },
-  {
-    id: "std-3",
-    question: "Which is the best definition of reconciliation?",
-    answers: [
-      "Tie-outs that prove totals match across sources (e.g., bank vs ledger)",
-      "A colorful status page",
-      "Deleting rows until the totals agree",
-      "Hiding formulas to make the model cleaner"
-    ],
-    explanation: "Reconciliation creates trust by showing totals agree and errors are surfaced—not hidden."
-  },
-]
+const comprehensionComponent = getPhaseComponent(phaseScenario, "comprehensionCheck")
+if (!comprehensionComponent) {
+  throw new Error("Unit 01 Lesson 07 Phase 1 scenario is missing a comprehension check component.")
+}
+
+const turnAndTalkComponent = getPhaseComponent(phaseScenario, "turnAndTalk")
+if (!turnAndTalkComponent) {
+  throw new Error("Unit 01 Lesson 07 Phase 1 scenario is missing a turn and talk component.")
+}
+
+const comprehensionData = adaptComprehensionCheck(comprehensionComponent)
+const turnAndTalkData = adaptTurnAndTalk(turnAndTalkComponent)
 
 export default function Phase1Page() {
+  const currentPhase = phasesForHeader.find(phase => phase.sequence === phaseScenario.sequence)!
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 to-red-50">
-      <PhaseHeader unit={unit01Data} lesson={lesson07Data} phase={currentPhase} phases={lesson07Phases} />
+      <PhaseHeader
+        lesson={lessonHeader}
+        unit={unitHeader}
+        phase={currentPhase}
+        phases={phasesForHeader}
+      />
 
       <main className="container mx-auto px-4 py-8 space-y-8">
         <section className="space-y-6">
           <div className="text-center space-y-4">
-            <Badge className="bg-red-100 text-red-800 text-lg px-4 py-2">🎯 Phase 1: Hook</Badge>
-            <div className="max-w-4xl mx-auto space-y-8">
-              <Card className="border-red-200 bg-white shadow-lg">
-                <CardHeader className="text-center pb-4">
-                  <div className="mx-auto w-16 h-16 bg-red-100 rounded-full flex items-center justify-center mb-4">
-                    <AlertTriangle className="w-8 h-8 text-red-600" />
-                  </div>
-                  <CardTitle className="text-3xl font-bold text-red-800 mb-2">
-                    Production Kickoff: Investor-Ready by Today
-                  </CardTitle>
-                </CardHeader>
-                <CardContent className="prose prose-lg max-w-none">
-                  <p className="text-lg leading-relaxed text-red-900">
-                    Sarah Chen’s morning starts with a message from a potential investor:
-                    “We’re reviewing your model at 3 PM. Please send an audit‑ready version with
-                    a one‑screen summary. We’ll ask follow‑up questions live.”
-                  </p>
-                  <p className="text-lg leading-relaxed text-red-900">
-                    This is high‑pressure and very real. Investors trust models that are built
-                    with exact references, clear error handling, and reconciliation checks. Today,
-                    you’ll finish your Smart Ledger, harden it with QA, and prepare decision‑ready
-                    outputs.
-                  </p>
-                  <div className="mt-4 grid grid-cols-1 md:grid-cols-2 gap-4">
-                    <div className="p-4 rounded-lg border bg-red-50 border-red-200">
-                      <h4 className="font-semibold text-red-800 flex items-center gap-2"><XCircle className="w-5 h-5" /> Failure Case</h4>
-                      <ul className="list-disc list-inside text-red-900 text-sm">
-                        <li>Hard‑coded numbers overwrite formulas</li>
-                        <li>VLOOKUP approximate match returns wrong client</li>
-                        <li>Charts point to A1:C10 and miss new rows</li>
-                        <li>No tie‑out to prove totals match</li>
-                      </ul>
-                    </div>
-                    <div className="p-4 rounded-lg border bg-green-50 border-green-200">
-                      <h4 className="font-semibold text-green-800 flex items-center gap-2"><CheckCircle className="w-5 h-5" /> Ready Example</h4>
-                      <ul className="list-disc list-inside text-green-900 text-sm">
-                        <li>XLOOKUP with exact match + IFNA("Not found")</li>
-                        <li>Named ranges and structured references</li>
-                        <li>Charts bound to tables; auto‑expanding</li>
-                        <li>Reconciliation section shows balance checks</li>
-                      </ul>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
-
-              <Card className="border-blue-200 bg-white">
-                <CardHeader>
-                  <CardTitle className="text-blue-900 flex items-center gap-2">
-                    <Target className="w-5 h-5" /> Do you know the standards?
-                  </CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <ComprehensionCheck
-                    questions={standardsQuiz as any}
-                    title="Production Standards Check"
-                    description="Confirm your understanding of exact lookups, structured refs, and reconciliation."
-                    showExplanations={true}
-                  />
-                </CardContent>
-              </Card>
-
-              <Card className="border-yellow-200 bg-yellow-50">
-                <CardHeader>
-                  <CardTitle className="text-yellow-900 flex items-center gap-2">
-                    <Users className="w-5 h-5" /> Turn & Talk (3 minutes)
-                  </CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <p className="text-yellow-900 font-medium mb-2">What makes a model trustworthy under pressure?</p>
-                  <ul className="list-disc list-inside text-yellow-900">
-                    <li>Which standards give investors confidence most quickly?</li>
-                    <li>Where does your current model still feel fragile?</li>
-                    <li>What would you check first before sending the file?</li>
-                  </ul>
-                </CardContent>
-              </Card>
-            </div>
+            <Badge className="bg-red-100 text-red-800 text-lg px-4 py-2">
+              🎯 Phase {phaseScenario.sequence}: {phaseScenario.name}
+            </Badge>
+            <h1 className="text-3xl font-bold text-gray-900">{phaseScenario.title}</h1>
+            <p className="text-lg text-gray-700 max-w-3xl mx-auto leading-relaxed">
+              {phaseScenario.summary}
+            </p>
           </div>
+        </section>
+
+        <section className="max-w-4xl mx-auto space-y-8">
+          <ScenarioNarrative blocks={phaseScenario.narrative} />
+
+          <Card className="border-red-200 bg-red-50">
+            <CardHeader>
+              <CardTitle className="text-red-800">
+                {comprehensionData.title ?? "Diagnostic Check"}
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ComprehensionCheck
+                questions={comprehensionData.questions}
+                title={comprehensionData.title}
+                description={comprehensionData.description ?? "Test your understanding"}
+                showExplanations={comprehensionData.showExplanations ?? true}
+                allowRetry={comprehensionData.allowRetry ?? true}
+              />
+            </CardContent>
+          </Card>
+
+          <Card className="border-purple-200 bg-purple-50">
+            <CardHeader>
+              <CardTitle className="text-purple-800 flex items-center gap-2">
+                <Users className="h-5 w-5" />
+                Turn and Talk: {turnAndTalkData.title}
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="text-purple-800 space-y-3">
+              <p className="font-medium">{turnAndTalkData.description}</p>
+              <ul className="list-disc list-inside space-y-1">
+                {turnAndTalkData.prompts.map((prompt, idx) => (
+                  <li key={idx}>{prompt}</li>
+                ))}
+              </ul>
+              <p className="text-sm italic">Duration: {turnAndTalkData.duration}</p>
+            </CardContent>
+          </Card>
         </section>
       </main>
 
-      <PhaseFooter unit={unit01Data} lesson={lesson07Data} phase={currentPhase} phases={lesson07Phases} />
+      <PhaseFooter
+        lesson={lessonHeader}
+        unit={unitHeader}
+        phase={currentPhase}
+        phases={phasesForHeader}
+      />
     </div>
   )
 }

--- a/bus-math-nextjs/src/app/student/unit01/lesson07/phase-2/page.tsx
+++ b/bus-math-nextjs/src/app/student/unit01/lesson07/phase-2/page.tsx
@@ -1,120 +1,87 @@
-'use client'
-
+import { ScenarioNarrative } from "@/components/student/ScenarioNarrative"
 import { PhaseHeader } from "@/components/student/PhaseHeader"
 import { PhaseFooter } from "@/components/student/PhaseFooter"
-import { lesson07Data, unit01Data, lesson07Phases } from "../lesson-data"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Badge } from "@/components/ui/badge"
-import { ArrowRightCircle, ClipboardList, Lightbulb, Target } from "lucide-react"
 import FillInTheBlank from "@/components/exercises/FillInTheBlank"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { getLessonScenario } from "@/data/scenarios"
+import {
+  adaptFillInTheBlank,
+  getPhaseBySequence,
+  getPhaseComponent,
+  mapLessonMetadata,
+  mapScenarioPhasesToLessonPhases
+} from "@/adapters/scenario-to-props"
+import { unit01Data } from "../lesson-data"
 
-const currentPhase = lesson07Phases[1]
+const lessonScenario = getLessonScenario("unit01", 7)
+const phasesForHeader = mapScenarioPhasesToLessonPhases(lessonScenario)
+const lessonHeader = mapLessonMetadata(lessonScenario)
+const phaseScenario = getPhaseBySequence(lessonScenario, 2)
+const unitHeader = {
+  id: lessonScenario.metadata.unitId,
+  title: lessonScenario.metadata.unitTitle,
+  sequence: unit01Data.sequence
+}
 
-const vocabSentences = [
-  { id: 'v1', text: 'Use {blank} to catch lookup errors and show friendly messages.', answer: 'IFNA', hint: 'Also IFERROR works when non-NA errors are possible', alternativeAnswers: ['IFERROR'] },
-  { id: 'v2', text: 'Excel Tables use {blank} references like Table1[Amount] that auto-expand.', answer: 'structured', hint: 'Not A1:C10' },
-  { id: 'v3', text: 'Switching from approximate matches to exact matches means setting match mode to {blank}.', answer: '0', hint: 'In XLOOKUP this is exact-match; in MATCH use 0', alternativeAnswers: ['exact'] },
-  { id: 'v4', text: 'A {blank} range gives a readable name to a cell or region.', answer: 'named', hint: 'Useful for drivers and assumptions', alternativeAnswers: ['named range'] },
-  { id: 'v5', text: 'A good {blank} proves totals agree across sources and flags mismatches.', answer: 'reconciliation', hint: 'Bank vs register; debits vs credits' },
-  { id: 'v6', text: 'Scenario behavior should update KPIs and the {blank} summary automatically.', answer: 'executive', hint: 'Short, decision-ready communication', alternativeAnswers: ['executive summary'] },
-]
+const fillInBlankComponent = getPhaseComponent(phaseScenario, "fillInTheBlank")
+if (!fillInBlankComponent) {
+  throw new Error("Unit 01 Lesson 07 Phase 2 scenario is missing a fill in the blank component.")
+}
+
+const fillInBlankData = adaptFillInTheBlank(fillInBlankComponent)
+const currentPhase = phasesForHeader.find(phase => phase.sequence === phaseScenario.sequence)!
 
 export default function Phase2Page() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 to-green-50">
-      <PhaseHeader unit={unit01Data} lesson={lesson07Data} phase={currentPhase} phases={lesson07Phases} />
+      <PhaseHeader
+        lesson={lessonHeader}
+        unit={unitHeader}
+        phase={currentPhase}
+        phases={phasesForHeader}
+      />
 
       <main className="container mx-auto px-4 py-8 space-y-8">
         <section className="space-y-6">
           <div className="text-center space-y-4">
-            <Badge className="bg-green-100 text-green-800 text-lg px-4 py-2">📚 Phase 2: Introduction</Badge>
-            <div className="max-w-4xl mx-auto space-y-8">
-              <Card className="border-green-200 bg-white">
-                <CardHeader>
-                  <CardTitle className="text-2xl font-bold text-gray-900 flex items-center gap-2">
-                    <ClipboardList className="w-5 h-5 text-green-700" /> QA Ladder for Lesson 07
-                  </CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-4 text-left">
-                  <div className="bg-green-50 border border-green-200 p-4 rounded-lg space-y-3">
-                    <p className="text-green-900 leading-relaxed">
-                      Lesson 07 is a guided QA lab. You will climb a ladder of quality checks one rung at a time. Everyone
-                      starts with clean trial balance basics. When that feels steady, you can explore the stretch checks that
-                      professional analysts use every day.
-                    </p>
-                    <div className="bg-white border border-green-200 rounded-lg p-4 space-y-2">
-                      <h3 className="font-semibold text-green-900 flex items-center gap-2"><ArrowRightCircle className="w-5 h-5" /> Tier 1 — Core Safety Checks</h3>
-                      <ul className="list-disc list-inside text-green-800 space-y-1">
-                        <li>Import the ledger data as a Table named <strong>Transactions</strong>.</li>
-                        <li>Run a trial balance test: <code>=SUM(Table[Debit]) - SUM(Table[Credit])</code>.</li>
-                        <li>Highlight at least two obvious errors (bad account name, negative liability, zero amount).</li>
-                      </ul>
-                    </div>
-                    <div className="bg-white border border-blue-200 rounded-lg p-4 space-y-2">
-                      <h3 className="font-semibold text-blue-900 flex items-center gap-2"><ArrowRightCircle className="w-5 h-5" /> Tier 2 — Pro Moves</h3>
-                      <ul className="list-disc list-inside text-blue-800 space-y-1">
-                        <li>Wrap lookups with <code>IFNA</code>/<code>IFERROR</code> so typos show friendly messages.</li>
-                        <li>Flag stale dates older than 90 days.</li>
-                        <li>Use <code>ROUND</code> so values like 199.995 display as 200.00.</li>
-                      </ul>
-                    </div>
-                    <div className="bg-white border border-purple-200 rounded-lg p-4 space-y-2">
-                      <h3 className="font-semibold text-purple-900 flex items-center gap-2"><ArrowRightCircle className="w-5 h-5" /> Tier 3 — Analyst Stretch</h3>
-                      <ul className="list-disc list-inside text-purple-800 space-y-1">
-                        <li>Build a mini QA dashboard (error counts + traffic-light status).</li>
-                        <li>Replace any static ranges with structured references or named tables.</li>
-                        <li>Write a one-sentence audit note that ties errors to next steps.</li>
-                      </ul>
-                    </div>
-                  </div>
-                  <div className="bg-blue-50 border border-blue-200 p-4 rounded-lg space-y-2">
-                    <div className="flex items-center gap-2 text-blue-900 font-semibold"><Lightbulb className="w-5 h-5" /> Why this ladder matters</div>
-                    <p className="text-blue-900 leading-relaxed">
-                      Sarah’s investors do not expect perfection in week three. They expect a ledger that shows problems fast
-                      and explains what to do about them. Each tier gives you another way to earn that trust.
-                    </p>
-                  </div>
-                </CardContent>
-              </Card>
-
-              <Card className="border-amber-200 bg-amber-50">
-                <CardHeader>
-                  <CardTitle className="text-amber-900 flex items-center gap-2">
-                    <Target className="w-5 h-5" /> Lesson 07 Learning Targets
-                  </CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-2 text-amber-900">
-                  <p>
-                    By the end of this lesson you will be able to explain how a trial balance proves ledger integrity, use
-                    validation formulas to catch messy data, and communicate findings in a short audit note.
-                  </p>
-                  <p>
-                    Keep these goals visible as you practice. They help you decide which tier to work on and when to push for the stretch challenge.
-                  </p>
-                </CardContent>
-              </Card>
-
-              <Card className="border-purple-200 bg-white">
-                <CardHeader>
-                  <CardTitle className="text-purple-900">Vocabulary Check: Standards & QA</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <FillInTheBlank 
-                    sentences={vocabSentences as any}
-                    title="Key Terms for Investor-Ready Models"
-                    description="Fill in the blanks to reinforce exact lookups, structured references, and reconciliation concepts."
-                    showWordList={true}
-                    randomizeWordOrder={true}
-                    showHints={true}
-                  />
-                </CardContent>
-              </Card>
-            </div>
+            <Badge className="bg-green-100 text-green-800 text-lg px-4 py-2">
+              📚 Phase {phaseScenario.sequence}: {phaseScenario.name}
+            </Badge>
+            <h1 className="text-3xl font-bold text-gray-900">{phaseScenario.title}</h1>
+            <p className="text-lg text-gray-700 max-w-3xl mx-auto leading-relaxed">
+              {phaseScenario.summary}
+            </p>
           </div>
+        </section>
+
+        <section className="max-w-4xl mx-auto space-y-8">
+          <ScenarioNarrative blocks={phaseScenario.narrative} />
+
+          <Card className="border-purple-200 bg-white">
+            <CardHeader>
+              <CardTitle className="text-purple-900">{fillInBlankData.title}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <FillInTheBlank
+                sentences={fillInBlankData.sentences as any}
+                title={fillInBlankData.title}
+                description="Fill in the blanks to reinforce exact lookups, structured references, and reconciliation concepts."
+                showWordList={true}
+                randomizeWordOrder={true}
+                showHints={true}
+              />
+            </CardContent>
+          </Card>
         </section>
       </main>
 
-      <PhaseFooter unit={unit01Data} lesson={lesson07Data} phase={currentPhase} phases={lesson07Phases} />
+      <PhaseFooter
+        lesson={lessonHeader}
+        unit={unitHeader}
+        phase={currentPhase}
+        phases={phasesForHeader}
+      />
     </div>
   )
 }

--- a/bus-math-nextjs/src/app/student/unit01/lesson07/phase-3/page.tsx
+++ b/bus-math-nextjs/src/app/student/unit01/lesson07/phase-3/page.tsx
@@ -1,103 +1,116 @@
-'use client'
-
+import { ScenarioNarrative } from "@/components/student/ScenarioNarrative"
 import { PhaseHeader } from "@/components/student/PhaseHeader"
 import { PhaseFooter } from "@/components/student/PhaseFooter"
-import { lesson07Data, unit01Data, lesson07Phases } from "../lesson-data"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
-import { ArrowRightCircle, Beaker, ListChecks, ShieldAlert, Users } from "lucide-react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Users } from "lucide-react"
 import SpreadsheetWrapper from "@/components/spreadsheet/SpreadsheetWrapper"
 import { trialBalanceTemplate } from "@/components/spreadsheet/SpreadsheetTemplates"
 import ErrorCheckingSystem from "@/components/business-simulations/ErrorCheckingSystem"
+import { getLessonScenario } from "@/data/scenarios"
+import {
+  adaptTurnAndTalk,
+  getPhaseBySequence,
+  getPhaseComponent,
+  mapLessonMetadata,
+  mapScenarioPhasesToLessonPhases
+} from "@/adapters/scenario-to-props"
+import { unit01Data } from "../lesson-data"
 
-const currentPhase = lesson07Phases[2]
+const lessonScenario = getLessonScenario("unit01", 7)
+const phasesForHeader = mapScenarioPhasesToLessonPhases(lessonScenario)
+const lessonHeader = mapLessonMetadata(lessonScenario)
+const phaseScenario = getPhaseBySequence(lessonScenario, 3)
+const unitHeader = {
+  id: lessonScenario.metadata.unitId,
+  title: lessonScenario.metadata.unitTitle,
+  sequence: unit01Data.sequence
+}
+
+const turnAndTalkComponent = getPhaseComponent(phaseScenario, "turnAndTalk")
+if (!turnAndTalkComponent) {
+  throw new Error("Unit 01 Lesson 07 Phase 3 scenario is missing a turn and talk component.")
+}
+
+const turnAndTalkData = adaptTurnAndTalk(turnAndTalkComponent)
+const currentPhase = phasesForHeader.find(phase => phase.sequence === phaseScenario.sequence)!
 
 export default function Phase3Page() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 to-purple-50">
-      <PhaseHeader unit={unit01Data} lesson={lesson07Data} phase={currentPhase} phases={lesson07Phases} />
+      <PhaseHeader
+        lesson={lessonHeader}
+        unit={unitHeader}
+        phase={currentPhase}
+        phases={phasesForHeader}
+      />
 
       <main className="container mx-auto px-4 py-8 space-y-8">
         <section className="space-y-6">
           <div className="text-center space-y-4">
-            <Badge className="bg-purple-100 text-purple-800 text-lg px-4 py-2">🛠️ Phase 3: Guided Practice</Badge>
-            <div className="max-w-4xl mx-auto space-y-8">
-              <Card className="border-purple-200 bg-white">
-                <CardHeader>
-                  <CardTitle className="text-purple-900 flex items-center gap-2">
-                    <Beaker className="w-5 h-5" /> Guided QA Lab: Trial Balance First
-                  </CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-4 text-left leading-relaxed">
-                  <p className="text-purple-900">
-                    Walk through these steps with your teacher. Pause after each step to be sure the numbers react exactly
-                    the way you expect. This builds the Tier 1 safety checks from the QA ladder.
-                  </p>
-                  <ol className="list-decimal list-inside space-y-2 text-purple-900">
-                    <li>Import <strong>unit01-ledger-lesson07-practice.csv</strong> as a Table named <strong>Transactions</strong>.</li>
-                    <li>Add a helper column <strong>Status</strong> with <code>=IF([@Debit]=0,"Review","")</code> so zero-amount rows stand out.</li>
-                    <li>Drop in this trial balance formula somewhere visible: <code>=SUM(Transactions[Debit]) - SUM(Transactions[Credit])</code>.</li>
-                    <li>If the difference is not zero, add a red message: <code>=IF(A1=0,"Balanced","Out of Balance — investigate")</code>.</li>
-                    <li>Filter the table to spot invalid accounts or negative liabilities. Add a comment noting what to fix.</li>
-                  </ol>
-                  <div className="bg-purple-100 border border-purple-200 rounded-lg p-4 text-purple-900 flex gap-3">
-                    <Users className="w-6 h-6 flex-shrink-0" />
-                    <div>
-                      <p className="font-semibold">Turn-and-talk moment (2 minutes)</p>
-                      <p>Share your balance result with a partner. If you both are balanced, swap filters and hunt for a new error you missed.</p>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
-
-              <Card className="border-green-200 bg-green-50">
-                <CardHeader>
-                  <CardTitle className="text-green-900 flex items-center gap-2">
-                    <ListChecks className="w-5 h-5" /> Scaffolded Practice: Build Tier 2 Checks
-                  </CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-4 text-left leading-relaxed">
-                  <p className="text-green-900">
-                    Try each enhancement below. Check it off when the flag behaves correctly. Use the interactive template to sketch formulas before committing them in Excel.
-                  </p>
-                  <div className="bg-white border rounded-lg p-4">
-                    <h4 className="font-semibold text-green-900 mb-2">Trial Balance Scratch Pad</h4>
-                    <SpreadsheetWrapper initialData={trialBalanceTemplate.data} />
-                  </div>
-                  <ul className="list-disc list-inside space-y-2 text-green-900">
-                    <li><strong>Friendly lookup errors:</strong> Wrap an XLOOKUP with <code>IFNA( ... , "Account name not found")</code>.</li>
-                    <li><strong>Stale date flag:</strong> Use <code>=IF(TODAY()-[@Date]&gt;90,"Stale","OK")</code> in a new column.</li>
-                    <li><strong>Rounding:</strong> Replace any raw totals with <code>ROUND(total,2)</code> so reports show clean cents.</li>
-                  </ul>
-                  <div className="bg-green-100 border border-green-200 rounded-lg p-4 text-green-900">
-                    <p className="font-semibold">Coach tip:</p>
-                    <p>If a formula breaks, rebuild it using the scratch pad above. Explain aloud what each function is doing before you copy it into the live file.</p>
-                  </div>
-                </CardContent>
-              </Card>
-
-              <Card className="border-orange-200 bg-orange-50">
-                <CardHeader>
-                  <CardTitle className="text-orange-900 flex items-center gap-2">
-                    <ShieldAlert className="w-5 h-5" /> Interactive Simulation: Error Signals
-                  </CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-3 text-orange-900 leading-relaxed">
-                  <p>
-                    Run the Error Checking System to see how professional dashboards highlight bad data. Match each alert to a fix in your workbook: add a validation rule, adjust a formula, or document the issue in your audit note.
-                  </p>
-                  <ErrorCheckingSystem />
-                  <div className="bg-orange-100 border border-orange-200 rounded-lg p-3 text-orange-900 flex items-center gap-2">
-                    <ArrowRightCircle className="w-5 h-5" /> Aim to clear at least one alert before moving on to independent practice.
-                  </div>
-                </CardContent>
-              </Card>
-            </div>
+            <Badge className="bg-purple-100 text-purple-800 text-lg px-4 py-2">
+              🛠️ Phase {phaseScenario.sequence}: {phaseScenario.name}
+            </Badge>
+            <h1 className="text-3xl font-bold text-gray-900">{phaseScenario.title}</h1>
+            <p className="text-lg text-gray-700 max-w-3xl mx-auto leading-relaxed">
+              {phaseScenario.summary}
+            </p>
           </div>
+        </section>
+
+        <section className="max-w-4xl mx-auto space-y-8">
+          <ScenarioNarrative blocks={phaseScenario.narrative} />
+
+          <Card className="border-green-200 bg-green-50">
+            <CardHeader>
+              <CardTitle className="text-green-900">Trial Balance Scratch Pad</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <p className="text-green-900">
+                Use this interactive template to sketch formulas before committing them in Excel.
+              </p>
+              <SpreadsheetWrapper initialData={trialBalanceTemplate.data} />
+            </CardContent>
+          </Card>
+
+          <Card className="border-orange-200 bg-orange-50">
+            <CardHeader>
+              <CardTitle className="text-orange-900">Interactive Simulation: Error Signals</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3 text-orange-900">
+              <p>
+                Run the Error Checking System to see how professional dashboards highlight bad data.
+              </p>
+              <ErrorCheckingSystem />
+            </CardContent>
+          </Card>
+
+          <Card className="border-purple-200 bg-purple-50">
+            <CardHeader>
+              <CardTitle className="text-purple-800 flex items-center gap-2">
+                <Users className="h-5 w-5" />
+                Turn and Talk: {turnAndTalkData.title}
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="text-purple-800 space-y-3">
+              <p className="font-medium">{turnAndTalkData.description}</p>
+              <ul className="list-disc list-inside space-y-1">
+                {turnAndTalkData.prompts.map((prompt, idx) => (
+                  <li key={idx}>{prompt}</li>
+                ))}
+              </ul>
+              <p className="text-sm italic">Duration: {turnAndTalkData.duration}</p>
+            </CardContent>
+          </Card>
         </section>
       </main>
 
-      <PhaseFooter unit={unit01Data} lesson={lesson07Data} phase={currentPhase} phases={lesson07Phases} />
+      <PhaseFooter
+        lesson={lessonHeader}
+        unit={unitHeader}
+        phase={currentPhase}
+        phases={phasesForHeader}
+      />
     </div>
   )
 }

--- a/bus-math-nextjs/src/app/student/unit01/lesson07/phase-4/page.tsx
+++ b/bus-math-nextjs/src/app/student/unit01/lesson07/phase-4/page.tsx
@@ -1,258 +1,130 @@
-'use client'
-
+import { ScenarioNarrative } from "@/components/student/ScenarioNarrative"
 import { PhaseHeader } from "@/components/student/PhaseHeader"
 import { PhaseFooter } from "@/components/student/PhaseFooter"
-import { lesson07Data, unit01Data, lesson07Phases } from "../lesson-data"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Badge } from "@/components/ui/badge"
 import ComprehensionCheck from "@/components/exercises/ComprehensionCheck"
 import ReflectionJournal from "@/components/exercises/ReflectionJournal"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Download } from "lucide-react"
+import { getLessonScenario } from "@/data/scenarios"
 import {
-  Beaker,
-  CheckCircle2,
-  ClipboardList,
-  Download,
-  FileText,
-  Gauge,
-  Target
-} from "lucide-react"
+  adaptComprehensionCheck,
+  adaptReflection,
+  getPhaseBySequence,
+  getPhaseComponent,
+  mapLessonMetadata,
+  mapScenarioPhasesToLessonPhases
+} from "@/adapters/scenario-to-props"
+import { unit01Data } from "../lesson-data"
 
-const currentPhase = lesson07Phases[3]
+const lessonScenario = getLessonScenario("unit01", 7)
+const phasesForHeader = mapScenarioPhasesToLessonPhases(lessonScenario)
+const lessonHeader = mapLessonMetadata(lessonScenario)
+const phaseScenario = getPhaseBySequence(lessonScenario, 4)
+const unitHeader = {
+  id: lessonScenario.metadata.unitId,
+  title: lessonScenario.metadata.unitTitle,
+  sequence: unit01Data.sequence
+}
 
-const independentQuestions = [
-  {
-    id: "trial-balance",
-    question: "What does it mean if SUM(Debit) - SUM(Credit) returns a non-zero number after you import the dataset?",
-    answers: [
-      "Your ledger is out of balance and you should investigate which rows caused the difference.",
-      "Excel miscalculated, so you should close the workbook and reopen it.",
-      "It proves the ledger is clean and you can publish the report immediately.",
-      "You must delete all rows that contain negative numbers." 
-    ],
-    explanation: "A non-zero difference signals the ledger is out of balance. The next step is to trace the rows that created the gap."
-  },
-  {
-    id: "stale-date",
-    question: "How should the Stale? column respond when TODAY() - Date is greater than 90?",
-    answers: [
-      "Show a warning like 'Stale' so Sarah knows to follow up on old invoices.",
-      "Display a dash because the age of data never matters in a ledger.",
-      "Automatically delete the row so the ledger balances again.",
-      "Convert the date to text so it cannot change." 
-    ],
-    explanation: "Flagging stale transactions helps Sarah spot invoices that need attention without deleting historical records."
-  },
-  {
-    id: "audit-note",
-    question: "Which detail makes an audit note investor-ready?",
-    answers: [
-      "Stating the number of errors found and the next corrective action.",
-      "Listing every formula used in the workbook alphabetically.",
-      "Sharing how many minutes the build required.",
-      "Thanking the reader for their patience." 
-    ],
-    explanation: "Investors need signal: the count of issues and the recommended next move."
-  }
-]
+const comprehensionComponent = getPhaseComponent(phaseScenario, "comprehensionCheck")
+if (!comprehensionComponent) {
+  throw new Error("Unit 01 Lesson 07 Phase 4 scenario is missing a comprehension check component.")
+}
 
-const reflectionPrompts = [
-  {
-    id: "courage-ledger",
-    category: "courage" as const,
-    prompt: "Where did you push yourself outside your comfort zone while chasing a ledger error today?",
-    placeholder: "Describe the error, the Excel feature you tried, and how it felt to keep digging..."
-  },
-  {
-    id: "adaptability-checks",
-    category: "adaptability" as const,
-    prompt: "What is one QA flag you could reuse on the next project, and how would you adapt it?",
-    placeholder: "Explain which rule worked here and what you would tweak for a different dataset..."
-  },
-  {
-    id: "persistence-audit",
-    category: "persistence" as const,
-    prompt: "How did you refine your audit sentence until it was clear and data-driven?",
-    placeholder: "Share the edits you made and what finally made the sentence feel ready for an investor..."
-  }
-]
+const reflectionComponent = getPhaseComponent(phaseScenario, "reflection")
+if (!reflectionComponent) {
+  throw new Error("Unit 01 Lesson 07 Phase 4 scenario is missing a reflection component.")
+}
+
+const comprehensionData = adaptComprehensionCheck(comprehensionComponent)
+const reflectionData = adaptReflection(reflectionComponent)
+const currentPhase = phasesForHeader.find(phase => phase.sequence === phaseScenario.sequence)!
+
+const practiceDataset = phaseScenario.datasets?.find(d => d.id === "unit01-ledger-lesson07-practice")
 
 export default function Phase4Page() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 to-orange-50">
       <PhaseHeader
-        unit={unit01Data}
-        lesson={lesson07Data}
+        lesson={lessonHeader}
+        unit={unitHeader}
         phase={currentPhase}
-        phases={lesson07Phases}
+        phases={phasesForHeader}
       />
 
       <main className="container mx-auto px-4 py-8 space-y-8">
         <section className="space-y-6">
           <div className="text-center space-y-4">
             <Badge className="bg-orange-100 text-orange-800 text-lg px-4 py-2">
-              🚀 Phase 4: Independent Practice — QA Stress Test
+              🚀 Phase {phaseScenario.sequence}: {phaseScenario.name}
             </Badge>
-            <h1 className="text-3xl font-bold text-gray-900">Build a Ledger that Spots Its Own Problems</h1>
-            <p className="text-lg text-gray-700 max-w-4xl mx-auto leading-relaxed">
-              Sarah’s investors want proof that her ledger can catch mistakes before they reach a boardroom. Use this
-              practice time to work through the QA ladder: start with trial balance basics, then layer in pro checks and
-              stretch challenges as you gain confidence.
+            <h1 className="text-3xl font-bold text-gray-900">{phaseScenario.title}</h1>
+            <p className="text-lg text-gray-700 max-w-3xl mx-auto leading-relaxed">
+              {phaseScenario.summary}
             </p>
           </div>
         </section>
 
-        <section className="max-w-4xl mx-auto space-y-6">
-          <Card className="border-blue-200 bg-blue-50">
-            <CardHeader>
-              <CardTitle className="text-blue-900 flex items-center gap-2">
-                <Download className="h-5 w-5" /> Practice Dataset
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="text-blue-900 space-y-3 leading-relaxed">
-              <p>
-                Import <strong>unit01-ledger-lesson07-practice.csv</strong> as a Table named <strong>Transactions</strong>.
-                The mix of clean entries and messy edge cases is intentional—you are here to catch them.
-              </p>
-              <a
-                href="/resources/unit01-ledger-lesson07-practice.csv"
-                download
-                className="inline-flex items-center gap-2 font-semibold underline text-blue-700"
-              >
-                Download: unit01-ledger-lesson07-practice.csv
-              </a>
-              <div className="bg-white border border-blue-200 rounded-lg p-3 text-blue-900 text-sm leading-relaxed">
-                <p className="font-semibold">Edge cases to test:</p>
-                <ul className="list-disc list-inside space-y-1">
-                  <li>Duplicate scenario names</li>
-                  <li>Stale <code>AsOfDate</code> values (&gt; 90 days old)</li>
-                  <li>Negative liabilities and zero-dollar rows</li>
-                  <li>Ledger entries that unbalance debits and credits</li>
-                </ul>
-              </div>
-            </CardContent>
-          </Card>
+        <section className="max-w-4xl mx-auto space-y-8">
+          <ScenarioNarrative blocks={phaseScenario.narrative} />
 
-          <Card>
+          {practiceDataset && (
+            <Card className="border-blue-200 bg-blue-50">
+              <CardHeader>
+                <CardTitle className="text-blue-900 flex items-center gap-2">
+                  <Download className="h-5 w-5" /> {practiceDataset.title}
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="text-blue-900 space-y-3">
+                <p>{practiceDataset.description}</p>
+                <a
+                  href={practiceDataset.path}
+                  download
+                  className="inline-flex items-center gap-2 font-semibold underline text-blue-700"
+                >
+                  Download: {practiceDataset.title}
+                </a>
+              </CardContent>
+            </Card>
+          )}
+
+          <Card className="border-purple-200 bg-white">
             <CardHeader>
-              <CardTitle className="text-gray-900 flex items-center gap-2">
-                <ClipboardList className="h-5 w-5" /> Independent Build Steps
+              <CardTitle className="text-purple-800">
+                {comprehensionData.title ?? "QA Self-Check"}
               </CardTitle>
             </CardHeader>
-            <CardContent className="text-gray-800 space-y-4 leading-relaxed">
-              <div className="space-y-4">
-                <div className="bg-white border border-gray-200 rounded-lg p-4">
-                  <h3 className="font-semibold text-gray-900 flex items-center gap-2">
-                    <Target className="w-5 h-5" /> Tier 1 — Core (everyone completes)
-                  </h3>
-                  <ol className="list-decimal list-inside text-base text-gray-800 space-y-1">
-                    <li>Confirm <code>=SUM(Transactions[Debit])</code> equals <code>=SUM(Transactions[Credit])</code>. Highlight the variance if it is not zero.</li>
-                    <li>Create an <strong>ErrorNote</strong> column that flags invalid accounts or negative liabilities with plain-language messages.</li>
-                    <li>Document two issues you found in a comments cell (what went wrong, how to fix it).</li>
-                  </ol>
-                </div>
-                <div className="bg-white border border-blue-200 rounded-lg p-4">
-                  <h3 className="font-semibold text-blue-900 flex items-center gap-2">
-                    <Gauge className="w-5 h-5" /> Tier 2 — Pro (add after Tier 1 is stable)
-                  </h3>
-                  <ol className="list-decimal list-inside text-base text-blue-900 space-y-1">
-                    <li>Wrap lookups with <code>IFNA</code> so typos return friendly prompts instead of error codes.</li>
-                    <li>Add a <strong>Stale?</strong> column: <code>=IF(TODAY()-[@Date]&gt;90,"Stale","OK")</code>.</li>
-                    <li>Use <code>ROUND(total,2)</code> or <code>MROUND</code> to present dollars with clean cents.</li>
-                  </ol>
-                </div>
-                <div className="bg-white border border-purple-200 rounded-lg p-4">
-                  <h3 className="font-semibold text-purple-900 flex items-center gap-2">
-                    <Beaker className="w-5 h-5" /> Tier 3 — Analyst Stretch
-                  </h3>
-                  <ol className="list-decimal list-inside text-base text-purple-900 space-y-1">
-                    <li>Build a mini QA dashboard: error counts, balanced/unbalanced status, traffic-light icons.</li>
-                    <li>Replace any A1:C10 references with structured table names or named ranges.</li>
-                    <li>Write a one-sentence audit note such as “Ledger caught 3 invalid accounts and 1 stale invoice; all other entries reconcile.”</li>
-                  </ol>
-                </div>
-              </div>
-              <div className="bg-orange-100 border border-orange-200 rounded-lg p-4 text-orange-900 flex gap-3">
-                <Gauge className="h-6 w-6 flex-shrink-0" />
-                <p>
-                  Pro tip: duplicate your sheet before stress testing an edge case. Compare “Before QA” and “After QA” to measure how much cleaner your ledger becomes.
-                </p>
-              </div>
+            <CardContent>
+              <ComprehensionCheck
+                questions={comprehensionData.questions}
+                title={comprehensionData.title}
+                description={comprehensionData.description ?? "Confirm your understanding"}
+                showExplanations={comprehensionData.showExplanations ?? true}
+                allowRetry={comprehensionData.allowRetry ?? true}
+              />
             </CardContent>
           </Card>
 
           <Card className="border-green-200 bg-green-50">
             <CardHeader>
-              <CardTitle className="text-green-900 flex items-center gap-2">
-                <CheckCircle2 className="h-5 w-5" /> Investor-Ready Quality Checklist
-              </CardTitle>
+              <CardTitle className="text-green-800">{reflectionData.title}</CardTitle>
             </CardHeader>
-            <CardContent className="text-green-900 space-y-2 leading-relaxed">
-              <ul className="list-disc list-inside space-y-2 text-base">
-                <li>Trial balance check returns zero when the ledger is clean and flags a gap when it is not.</li>
-                <li>ErrorNote column pinpoints specific problems (invalid account, negative liability, stale date).</li>
-                <li>All lookup formulas that can fail are wrapped in <code>IFNA</code> or <code>IFERROR</code> with plain-language messages.</li>
-                <li>Structured references or named ranges power every formula, chart, and validation rule.</li>
-                <li>Your audit note states the number of issues and the next action in under 25 words.</li>
-              </ul>
+            <CardContent>
+              <ReflectionJournal
+                unitTitle={reflectionData.unitTitle ?? lessonScenario.metadata.unitTitle}
+                prompts={reflectionData.prompts}
+              />
             </CardContent>
           </Card>
-
-          <Card className="border-amber-200 bg-amber-50">
-            <CardHeader>
-              <CardTitle className="text-amber-900 flex items-center gap-2">
-                <FileText className="h-5 w-5" /> Audit Note Examples
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="text-amber-900 space-y-3 leading-relaxed">
-              <p>
-                Investors read for signal, not story time. Use one of these stems to keep your message sharp:
-              </p>
-              <ul className="list-disc list-inside space-y-1 text-base">
-                <li><strong>Balanced with flags:</strong> “Ledger balances but flagged <strong>{"{count}"}</strong> invalid accounts; update vendor list before publishing.”</li>
-                <li><strong>Out of balance:</strong> “Debits trail credits by <strong>${"{variance}"}</strong>; review invoices dated before <strong>{"{date}"}</strong> for typos.”</li>
-                <li><strong>Clean pass:</strong> “All transactions reconcile and no validation flags triggered; ready for investor packet.”</li>
-              </ul>
-              <p>
-                Keep the sentence under 25 words. Mention the key KPI or flag and the action you recommend next.
-              </p>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-gray-900 flex items-center gap-2">
-                <Target className="h-5 w-5" /> Stretch Yourself
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="text-gray-800 space-y-3 leading-relaxed">
-              <p>
-                Ready for more? Build a pivot table that groups error types by account family. Add a slicer by month so Sarah can spot patterns quickly.
-              </p>
-              <p>
-                Bonus challenge: write a second audit sentence aimed at a different audience (bookkeeper vs. investor) and notice how the language shifts.
-              </p>
-            </CardContent>
-          </Card>
-
-          <ComprehensionCheck
-            title="QA Readiness Check"
-            description="Confirm you can explain the core QA moves before submitting your ledger."
-            questions={independentQuestions}
-            showExplanations
-          />
-
-          <ReflectionJournal
-            unitTitle="Ledger QA Reflection"
-            prompts={reflectionPrompts}
-          />
         </section>
       </main>
 
       <PhaseFooter
-        unit={unit01Data}
-        lesson={lesson07Data}
+        lesson={lessonHeader}
+        unit={unitHeader}
         phase={currentPhase}
-        phases={lesson07Phases}
+        phases={phasesForHeader}
       />
     </div>
   )

--- a/bus-math-nextjs/src/app/student/unit01/lesson07/phase-6/page.tsx
+++ b/bus-math-nextjs/src/app/student/unit01/lesson07/phase-6/page.tsx
@@ -1,68 +1,83 @@
-'use client'
-
+import { ScenarioNarrative } from "@/components/student/ScenarioNarrative"
 import { PhaseHeader } from "@/components/student/PhaseHeader"
 import { PhaseFooter } from "@/components/student/PhaseFooter"
-import { lesson07Data, unit01Data, lesson07Phases } from "../lesson-data"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Badge } from "@/components/ui/badge"
-import { Stars, ArrowRight } from "lucide-react"
 import ReflectionJournal from "@/components/exercises/ReflectionJournal"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { getLessonScenario } from "@/data/scenarios"
+import {
+  adaptReflection,
+  getPhaseBySequence,
+  getPhaseComponent,
+  mapLessonMetadata,
+  mapScenarioPhasesToLessonPhases
+} from "@/adapters/scenario-to-props"
+import { unit01Data } from "../lesson-data"
 
-const currentPhase = lesson07Phases[5]
+const lessonScenario = getLessonScenario("unit01", 7)
+const phasesForHeader = mapScenarioPhasesToLessonPhases(lessonScenario)
+const lessonHeader = mapLessonMetadata(lessonScenario)
+const phaseScenario = getPhaseBySequence(lessonScenario, 6)
+const unitHeader = {
+  id: lessonScenario.metadata.unitId,
+  title: lessonScenario.metadata.unitTitle,
+  sequence: unit01Data.sequence
+}
 
-const capPrompts = [
-  { id: 'cap-courage', category: 'courage', prompt: 'Where did you show courage—speaking up about an error or presenting a tough finding?', placeholder: 'Describe the moment and why it mattered to the model’s credibility.' },
-  { id: 'cap-adapt', category: 'adaptability', prompt: 'What formula or reference did you change to make the model more reliable?', placeholder: 'Explain what was fragile before and how you improved it.' },
-  { id: 'cap-persist', category: 'persistence', prompt: 'What bug took the longest to fix? How did you finally solve it?', placeholder: 'Note the steps you tried and what you learned from the process.' },
-]
+const reflectionComponent = getPhaseComponent(phaseScenario, "reflection")
+if (!reflectionComponent) {
+  throw new Error("Unit 01 Lesson 07 Phase 6 scenario is missing a reflection component.")
+}
+
+const reflectionData = adaptReflection(reflectionComponent)
+const currentPhase = phasesForHeader.find(phase => phase.sequence === phaseScenario.sequence)!
 
 export default function Phase6Page() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 to-indigo-50">
-      <PhaseHeader unit={unit01Data} lesson={lesson07Data} phase={currentPhase} phases={lesson07Phases} />
+      <PhaseHeader
+        lesson={lessonHeader}
+        unit={unitHeader}
+        phase={currentPhase}
+        phases={phasesForHeader}
+      />
 
       <main className="container mx-auto px-4 py-8 space-y-8">
         <section className="space-y-6">
           <div className="text-center space-y-4">
-            <Badge className="bg-indigo-100 text-indigo-800 text-lg px-4 py-2">🧭 Phase 6: Closing</Badge>
-            <div className="max-w-4xl mx-auto space-y-8">
-              <Card className="border-indigo-200 bg-white">
-                <CardHeader>
-                  <CardTitle className="text-indigo-900 flex items-center gap-2"><Stars className="w-5 h-5" /> Readiness & Handoff</CardTitle>
-                </CardHeader>
-                <CardContent className="prose prose-lg max-w-none">
-                  <p className="text-indigo-900">
-                    Today you moved from “it calculates” to “it convinces.” Your ledger now has exact references,
-                    validation, reconciliation, and clear messages. You are ready to share a concise, decision‑ready
-                    executive summary. Next lesson focuses on final polish and stakeholder review.
-                  </p>
-                </CardContent>
-              </Card>
-
-              <Card className="border-green-200 bg-green-50">
-                <CardHeader>
-                  <CardTitle className="text-green-900">CAP Reflection</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <ReflectionJournal unitTitle="CAP Reflection: Production Studio" prompts={capPrompts as any} />
-                </CardContent>
-              </Card>
-
-              <Card className="border-blue-200 bg-blue-50">
-                <CardHeader>
-                  <CardTitle className="text-blue-900 flex items-center gap-2"><ArrowRight className="w-5 h-5" /> Preview: Lesson 08</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  Final polish, stakeholder review, and professional examples. You’ll refine visuals, tighten the
-                  executive summary, and practice fast scenario switching for Q&A.
-                </CardContent>
-              </Card>
-            </div>
+            <Badge className="bg-indigo-100 text-indigo-800 text-lg px-4 py-2">
+              🧭 Phase {phaseScenario.sequence}: {phaseScenario.name}
+            </Badge>
+            <h1 className="text-3xl font-bold text-gray-900">{phaseScenario.title}</h1>
+            <p className="text-lg text-gray-700 max-w-3xl mx-auto leading-relaxed">
+              {phaseScenario.summary}
+            </p>
           </div>
+        </section>
+
+        <section className="max-w-4xl mx-auto space-y-8">
+          <ScenarioNarrative blocks={phaseScenario.narrative} />
+
+          <Card className="border-green-200 bg-green-50">
+            <CardHeader>
+              <CardTitle className="text-green-800">{reflectionData.title}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ReflectionJournal
+                unitTitle={reflectionData.unitTitle ?? lessonScenario.metadata.unitTitle}
+                prompts={reflectionData.prompts}
+              />
+            </CardContent>
+          </Card>
         </section>
       </main>
 
-      <PhaseFooter unit={unit01Data} lesson={lesson07Data} phase={currentPhase} phases={lesson07Phases} />
+      <PhaseFooter
+        lesson={lessonHeader}
+        unit={unitHeader}
+        phase={currentPhase}
+        phases={phasesForHeader}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
Refactor student phase pages for Unit 01 Lessons 05-07 to consume scenario data from the shared scenario registry, establishing single source of truth for lesson content.

## Changes
- **Lesson 05**: All 6 phases now consume data via `getLessonScenario("unit01", 5)`
- **Lesson 06**: All 6 phases now consume data via `getLessonScenario("unit01", 6)`  
- **Lesson 07**: All 6 phases now consume data via `getLessonScenario("unit01", 7)`
- Use ScenarioNarrative component for all narrative blocks
- Apply adapters: `adaptComprehensionCheck`, `adaptTurnAndTalk`, `adaptFillInTheBlank`, `adaptReflection`
- Handle datasets via `phaseScenario.datasets`
- Maintain six-phase layout structure and navigation wrappers

## Test Plan
- [x] `npm run lint` passes (warnings only, no errors)
- [x] `npm run build` completes successfully
- [ ] Verify lesson 05 phases 1-6 render correctly in browser
- [ ] Verify lesson 06 phases 1-6 render correctly in browser
- [ ] Verify lesson 07 phases 1-6 render correctly in browser
- [ ] Confirm interactive components function (ComprehensionCheck, FillInTheBlank, etc.)
- [ ] Validate datasets download correctly
- [ ] Check phase navigation between lessons

## Related
- Resolves #59
- Part of epic #104 (Expand scenario registry across Units 01-08)
- Follows patterns from PRs #54, #55, #106, #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)